### PR TITLE
Fix issue #465

### DIFF
--- a/MyFlightbook.Web/Controls/mfbLogbook.ascx
+++ b/MyFlightbook.Web/Controls/mfbLogbook.ascx
@@ -323,7 +323,7 @@
                 <asp:TemplateField>
                     <ItemStyle CssClass="noprint" />
                     <ItemTemplate>
-                        <uc7:popmenu ID="popmenu1" runat="server" Visible="<%# IsViewingOwnFlights && !IsInSelectMode %>" OffsetX="-180" OffsetY="-20">
+                        <uc7:popmenu ID="popmenu1" runat="server" Visible="<%# IsViewingOwnFlights && !IsInSelectMode && !IsReadOnly %>" OffsetX="-180" OffsetY="-20">
                             <MenuContent>
                                 <uc1:mfbFlightContextMenu runat="server" ID="mfbFlightContextMenu" SignTargetFormatString="~/Member/RequestSigs.aspx?id={0}" OnDeleteFlight="mfbFlightContextMenu_DeleteFlight" OnSendFlight="mfbFlightContextMenu_SendFlight" />
                             </MenuContent>
@@ -339,7 +339,7 @@
                         <asp:HyperLink ID="lnkSignEntry" runat="server"
                             NavigateUrl='<%# String.Format("~/Member/SignFlight.aspx?idFlight={0}&ret={1}", Eval("FlightID"), HttpUtility.UrlEncode(Page.Request.Url.PathAndQuery)) %>'
                             Text='<%# ((LogbookEntry.SignatureState) Eval("CFISignatureState")) == LogbookEntry.SignatureState.Invalid ? Resources.SignOff.LogbookResign : Resources.SignOff.LogbookSign %>' 
-                            Visible='<%# !IsViewingOwnFlights && ((LogbookEntry.SignatureState) Eval("CFISignatureState")) != LogbookEntry.SignatureState.Valid %>'></asp:HyperLink>
+                            Visible='<%# !IsViewingOwnFlights && !IsReadOnly && ((LogbookEntry.SignatureState) Eval("CFISignatureState")) != LogbookEntry.SignatureState.Valid %>'></asp:HyperLink>
                     </ItemTemplate>
                     <ItemStyle CssClass="noprint" />
                 </asp:TemplateField>

--- a/MyFlightbook.Web/Member/FlightDetail.aspx.cs
+++ b/MyFlightbook.Web/Member/FlightDetail.aspx.cs
@@ -20,7 +20,7 @@ using System.Web.UI.WebControls;
 
 /******************************************************
  * 
- * Copyright (c) 2017-2019 MyFlightbook LLC
+ * Copyright (c) 2017-2020 MyFlightbook LLC
  * Contact myflightbook-at-gmail.com for more information
  *
 *******************************************************/
@@ -180,6 +180,7 @@ public partial class Member_FlightDetail : System.Web.UI.Page
             mvReturn.SetActiveView(vwReturnStudent);
             lnkReturnStudent.NavigateUrl = String.Format(CultureInfo.InvariantCulture, "~/Member/StudentLogbook.aspx?student={0}", szFlightOwner);
             lnkReturnStudent.Text = String.Format(CultureInfo.CurrentCulture, Resources.Profile.ReturnToStudent, MyFlightbook.Profile.GetUser(szFlightOwner).UserFullName);
+            popmenu.Visible = false;
         }
 
         // If we're here, we're authorized
@@ -219,7 +220,7 @@ public partial class Member_FlightDetail : System.Web.UI.Page
     protected void mfbQueryDescriptor1_QueryUpdated(object sender, FilterItemClicked fic)
     {
         if (fic == null)
-            throw new ArgumentNullException("fic");
+            throw new ArgumentNullException(nameof(fic));
         Restriction.ClearRestriction(fic.FilterItem);
         UpdateRestriction();
     }
@@ -591,7 +592,7 @@ public partial class Member_FlightDetail : System.Web.UI.Page
     protected void OnRowDatabound(object sender, GridViewRowEventArgs e)
     {
         if (e == null)
-            throw new ArgumentNullException("e");
+            throw new ArgumentNullException(nameof(e));
         if (e.Row.RowType == DataControlRowType.DataRow)
         {
             Image i = (Image)e.Row.FindControl("imgPin");
@@ -674,7 +675,7 @@ public partial class Member_FlightDetail : System.Web.UI.Page
     protected void fmvLE_DataBound(object sender, EventArgs e)
     {
         if (e == null)
-            throw new ArgumentNullException("e");
+            throw new ArgumentNullException(nameof(e));
 
         FormView fv = sender as FormView;
         LogbookEntryDisplay le = (LogbookEntryDisplay)fv.DataItem;
@@ -716,7 +717,7 @@ public partial class Member_FlightDetail : System.Web.UI.Page
     protected void btnMetars_Click(object sender, EventArgs e)
     {
         if (e == null)
-            throw new ArgumentNullException("e");
+            throw new ArgumentNullException(nameof(e));
         Controls_METAR m = (Controls_METAR)fmvLE.FindControl("METARDisplay");
         m.METARs = new ADDSService().LatestMETARSForAirports(CurrentFlight.Route);
     }
@@ -724,7 +725,7 @@ public partial class Member_FlightDetail : System.Web.UI.Page
     protected void mfbFlightContextMenu_DeleteFlight(object sender, LogbookEventArgs e)
     {
         if (e == null)
-            throw new ArgumentNullException("e");
+            throw new ArgumentNullException(nameof(e));
 
         LogbookEntryDisplay.FDeleteEntry(e.FlightID, Page.User.Identity.Name);
         Response.Redirect(TargetPage);
@@ -733,7 +734,7 @@ public partial class Member_FlightDetail : System.Web.UI.Page
     protected void mfbFlightContextMenu_SendFlight(object sender, LogbookEventArgs e)
     {
         if (e == null)
-            throw new ArgumentNullException("e");
+            throw new ArgumentNullException(nameof(e));
 
         mfbSendFlight.SendFlight(e.FlightID);
     }


### PR DESCRIPTION
Issue #465: viewing student logbook should suppress ability to make edits/changes
 - New "IsReadOnly" flag on mfbLogbook (in anticipation of sharekey work), disables flight popmenu
 - Disable flight selection if not viewing own flights
 - Disable pop-menu in flight details as well if not own flight
 - Clean up some warnings