### PR TITLE
Issue #592: rearrange edit-flight screen

### DIFF
--- a/MyFlightbook.Web/App_GlobalResources/LogbookEntry.designer.cs
+++ b/MyFlightbook.Web/App_GlobalResources/LogbookEntry.designer.cs
@@ -97,7 +97,7 @@ namespace Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Auto-fill fills in missing information that can be determined from your route of flight, the times provided above, and any optional telemetry file you provide above..
+        ///   Looks up a localized string similar to Fills in missing information that can be determined from your route of flight, the times provided above, and any optional telemetry file you provide above..
         /// </summary>
         internal static string AutoFillDescription {
             get {
@@ -1033,6 +1033,15 @@ namespace Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Landings and Approaches.
+        /// </summary>
+        internal static string HeaderApproachesLandings {
+            get {
+                return ResourceManager.GetString("HeaderApproachesLandings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Images for this flight.
         /// </summary>
         internal static string HeaderImagesForFlight {
@@ -1047,6 +1056,15 @@ namespace Resources {
         internal static string HeaderImagesVideosForFlight {
             get {
                 return ResourceManager.GetString("HeaderImagesVideosForFlight", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Times.
+        /// </summary>
+        internal static string HeaderTimes {
+            get {
+                return ResourceManager.GetString("HeaderTimes", resourceCulture);
             }
         }
         
@@ -1872,7 +1890,7 @@ namespace Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to if there are additional properties you&apos;d like to see..
+        ///   Looks up a localized string similar to about additional properties.
         /// </summary>
         internal static string NewPropertyPrompt2 {
             get {

--- a/MyFlightbook.Web/App_GlobalResources/LogbookEntry.resx
+++ b/MyFlightbook.Web/App_GlobalResources/LogbookEntry.resx
@@ -457,7 +457,7 @@
     <value>Contact us</value>
   </data>
   <data name="NewPropertyPrompt2" xml:space="preserve">
-    <value>if there are additional properties you'd like to see.</value>
+    <value>about additional properties</value>
   </data>
   <data name="RepeatFlight" xml:space="preserve">
     <value>Repeat this flight</value>
@@ -887,7 +887,7 @@
     <value>Auto Fill</value>
   </data>
   <data name="AutoFillDescription" xml:space="preserve">
-    <value>Auto-fill fills in missing information that can be determined from your route of flight, the times provided above, and any optional telemetry file you provide above.</value>
+    <value>Fills in missing information that can be determined from your route of flight, the times provided above, and any optional telemetry file you provide above.</value>
   </data>
   <data name="AutoFillPrompt" xml:space="preserve">
     <value>Auto-fill</value>
@@ -1294,5 +1294,11 @@ Proceed with import?</value>
   </data>
   <data name="ImportWizardBeginButton" xml:space="preserve">
     <value>Proceed to Upload...</value>
+  </data>
+  <data name="HeaderApproachesLandings" xml:space="preserve">
+    <value>Landings and Approaches</value>
+  </data>
+  <data name="HeaderTimes" xml:space="preserve">
+    <value>Times</value>
   </data>
 </root>

--- a/MyFlightbook.Web/Controls/mfbEditFlight.ascx
+++ b/MyFlightbook.Web/Controls/mfbEditFlight.ascx
@@ -14,240 +14,225 @@
 <%@ Register Src="~/Controls/popmenu.ascx" TagPrefix="uc1" TagName="popmenu" %>
 <asp:Panel ID="pnlContainer" runat="server" DefaultButton="btnAddFlight" 
     meta:resourcekey="pnlContainerResource1">
-    <asp:Panel ID="pnlFlightInfo" runat="server" CssClass="flightinfoblock" 
-        meta:resourcekey="pnlFlightInfoResource1">
+    <div class="flightinfoblock">
         <div class="header">
             <asp:Label ID="lblSectionGeneralInfo" runat="server" Text="General Flight Info" 
                 meta:resourcekey="Label6Resource1"></asp:Label>
-            
         </div>
-        <div class="itemtime">
-            <div class="itemlabel"><asp:Label ID="Label7" runat="server" Text="Date of Flight" 
-                    meta:resourcekey="Label7Resource1"></asp:Label></div>
-            <div class="itemdata">
-                <uc1:mfbTypeInDate ID="mfbDate" runat="server" TabIndex="1" DefaultType="Today" />
-                <div>
-                <asp:CustomValidator ID="valDate" runat="server" ErrorMessage="Date of flight should be today or in the past." CssClass="error"
-                    onservervalidate="valDate_ServerValidate" Display="Dynamic" 
-                    meta:resourcekey="valDateResource1"></asp:CustomValidator></div>
-            </div>
-        </div>
-        <div class="itemtime">
-            <div class="itemlabel"><asp:Label ID="Label8" runat="server" Text="Aircraft:" 
-                    meta:resourcekey="Label8Resource1"></asp:Label>
-                <asp:LinkButton ID="lnkAddAircraft" runat="server" CausesValidation="False" 
-                    onclick="lnkAddAircraft_Click" Text="(Add...)" 
-                    meta:resourcekey="lnkAddAircraftResource1"></asp:LinkButton>
-            </div>
-            <div class="itemdata">
-                <asp:DropDownList ID="cmbAircraft" runat="server" TabIndex="2" Width="200px" AutoPostBack="true" OnSelectedIndexChanged="cmbAircraft_SelectedIndexChanged" 
-                    meta:resourcekey="cmbAircraftResource1">
-                </asp:DropDownList>
-                <script>
-                    function currentlySelectedAircraft() {
-                        return document.getElementById('<% =cmbAircraft.ClientID %>').value;
-                    }
-                </script>
-                <div>
-                    <asp:RequiredFieldValidator ID="RequiredFieldValidator2" runat="server" 
-                    ControlToValidate="cmbAircraft" Display="Dynamic"
-                    CssClass="error" 
-                    ErrorMessage='Please select an aircraft, or click "Add" to add a new one' 
-                    meta:resourcekey="RequiredFieldValidator2Resource1"></asp:RequiredFieldValidator>
-                </div>
-                <div>
-                    <asp:Label ID="lblShowCatClass" runat="server" CssClass="fineprint" 
-                    meta:resourcekey="lblShowCatClassResource1"></asp:Label>
-                    <uc14:mfbTooltip ID="mfbTooltip1" runat="server" BodyContent="<%$ Resources:LocalizedText, EditFlightAltCatclassTooltip %>" />
+        <div>
+            <div class="itemtime">
+                <div class="itemlabel"><asp:Label ID="Label7" runat="server" Text="Date of Flight" 
+                        meta:resourcekey="Label7Resource1"></asp:Label></div>
+                <div class="itemdata">
+                    <uc1:mfbTypeInDate ID="mfbDate" runat="server" TabIndex="1" DefaultType="Today" Width="90%" />
+                    <div>
+                    <asp:CustomValidator ID="valDate" runat="server" ErrorMessage="Date of flight should be today or in the past." CssClass="error"
+                        onservervalidate="valDate_ServerValidate" Display="Dynamic" 
+                        meta:resourcekey="valDateResource1"></asp:CustomValidator></div>
                 </div>
             </div>
-            <asp:Panel ID="pnlAltCatClass" runat="server" CssClass="flightinfoitem" 
-                Height="0px" style="overflow:hidden; padding-bottom:4px;" 
-                meta:resourcekey="pnlAltCatClassResource1">
-                    <asp:DropDownList ID="cmbCatClasses" TabIndex="3" runat="server" AppendDataBoundItems="true"  DataValueField="IDCatClassAsInt" 
-                        DataTextField="CatClass" EnableViewState="false" 
-                        meta:resourcekey="cmbCatClassesResource1">
-                        <asp:ListItem Selected="True" Value="0" Text="<%$ Resources:LocalizedText, EditFlightDefaultCatClass %>"></asp:ListItem>
+            <div class="itemtime">
+                <div class="itemlabel"><asp:Label ID="Label8" runat="server" Text="Aircraft:" 
+                        meta:resourcekey="Label8Resource1"></asp:Label>
+                    <asp:LinkButton ID="lnkAddAircraft" runat="server" CausesValidation="False" 
+                        onclick="lnkAddAircraft_Click" Text="(Add...)" 
+                        meta:resourcekey="lnkAddAircraftResource1"></asp:LinkButton>
+                </div>
+                <div class="itemdata">
+                    <asp:DropDownList ID="cmbAircraft" runat="server" TabIndex="2" Width="90%" AutoPostBack="true" OnSelectedIndexChanged="cmbAircraft_SelectedIndexChanged" 
+                        meta:resourcekey="cmbAircraftResource1">
                     </asp:DropDownList>
-            </asp:Panel>
-            <cc1:CollapsiblePanelExtender ID="cpeAltCatClass" runat="server" 
-                CollapseControlID="lblShowCatClass" ExpandControlID="lblShowCatClass" CollapsedText="<%$ Resources:LocalizedText, ClickToShowAlternateCatClass %>"
-             ExpandedText="<%$ Resources:LocalizedText, ClickToHideAlternateCatClass %>" 
-                TargetControlID="pnlAltCatClass" TextLabelID="lblShowCatClass" Collapsed="True" 
-                Enabled="True" >
-            </cc1:CollapsiblePanelExtender>
+                    <script>
+                        function currentlySelectedAircraft() {
+                            return document.getElementById('<% =cmbAircraft.ClientID %>').value;
+                        }
+                    </script>
+                    <div>
+                        <asp:RequiredFieldValidator ID="RequiredFieldValidator2" runat="server" 
+                        ControlToValidate="cmbAircraft" Display="Dynamic"
+                        CssClass="error" 
+                        ErrorMessage='Please select an aircraft, or click "Add" to add a new one' 
+                        meta:resourcekey="RequiredFieldValidator2Resource1"></asp:RequiredFieldValidator>
+                    </div>
+                    <div>
+                        <asp:Label ID="lblShowCatClass" runat="server" CssClass="fineprint" 
+                        meta:resourcekey="lblShowCatClassResource1"></asp:Label>
+                        <uc14:mfbTooltip ID="mfbTooltip1" runat="server" BodyContent="<%$ Resources:LocalizedText, EditFlightAltCatclassTooltip %>" />
+                    </div>
+                </div>
+                <asp:Panel ID="pnlAltCatClass" runat="server" CssClass="flightinfoitem" 
+                    Height="0px" style="overflow:hidden; padding-bottom:4px;" 
+                    meta:resourcekey="pnlAltCatClassResource1">
+                        <asp:DropDownList ID="cmbCatClasses" TabIndex="3" runat="server" AppendDataBoundItems="true"  DataValueField="IDCatClassAsInt" 
+                            DataTextField="CatClass" EnableViewState="false" 
+                            meta:resourcekey="cmbCatClassesResource1">
+                            <asp:ListItem Selected="True" Value="0" Text="<%$ Resources:LocalizedText, EditFlightDefaultCatClass %>"></asp:ListItem>
+                        </asp:DropDownList>
+                </asp:Panel>
+                <cc1:CollapsiblePanelExtender ID="cpeAltCatClass" runat="server" 
+                    CollapseControlID="lblShowCatClass" ExpandControlID="lblShowCatClass" CollapsedText="<%$ Resources:LocalizedText, ClickToShowAlternateCatClass %>"
+                 ExpandedText="<%$ Resources:LocalizedText, ClickToHideAlternateCatClass %>" 
+                    TargetControlID="pnlAltCatClass" TextLabelID="lblShowCatClass" Collapsed="True" 
+                    Enabled="True" >
+                </cc1:CollapsiblePanelExtender>
+            </div>
+            <div class="itemtime">
+                <div class="itemlabel">
+                    <asp:Label ID="Label9" runat="server" Text="Route:" 
+                        meta:resourcekey="Label9Resource1"></asp:Label>
+                    <uc14:mfbTooltip ID="mfbTooltip2" runat="server" BodyContent="<%$ Resources:Airports, MapNavaidTip %>" />
+                </div>
+                <div class="itemdata">
+                    <asp:TextBox ID="txtRoute" runat="server" Font-Size="Small" TabIndex="4" 
+                        Width="90%" meta:resourcekey="txtRouteResource1"></asp:TextBox>
+                </div>
+            </div>
+            <div class="itemtime">
+                <div class="itemlabel"><asp:Label ID="Label10" runat="server" Text="Comments:" 
+                        meta:resourcekey="Label10Resource1"></asp:Label>
+                </div>
+                <div class="itemdata">
+                    <asp:TextBox ID="txtComments" runat="server" TextMode="MultiLine" dir="auto" Font-Names="Arial"
+                        Font-Size="Small" TabIndex="5" Rows="2" Width="90%" 
+                        meta:resourcekey="txtCommentsResource1"></asp:TextBox>
+                </div>
+            </div>
         </div>
-        <div class="itemtime">
-            <div class="itemlabel">
-                <asp:Label ID="Label9" runat="server" Text="Route:" 
-                    meta:resourcekey="Label9Resource1"></asp:Label>
-                <uc14:mfbTooltip ID="mfbTooltip2" runat="server" BodyContent="<%$ Resources:Airports, MapNavaidTip %>" />
-            </div>
-            <div class="itemdata">
-                <asp:TextBox ID="txtRoute" runat="server" Font-Size="Small" TabIndex="4" 
-                    Width="200px" meta:resourcekey="txtRouteResource1"></asp:TextBox>
-            </div>
-        </div>
-        <div class="itemtime">
-            <div class="itemlabel"><asp:Label ID="Label10" runat="server" Text="Comments:" 
-                    meta:resourcekey="Label10Resource1"></asp:Label>
-            </div>
-            <div class="itemdata">
-                <asp:TextBox ID="txtComments" runat="server" TextMode="MultiLine" dir="auto" Font-Names="Arial"
-                    Font-Size="Small" TabIndex="5" Rows="3" Width="200px" 
-                    meta:resourcekey="txtCommentsResource1"></asp:TextBox>
-            </div>
-        </div>
-    </asp:Panel>
-    <asp:Panel ID="pnlFlightTimes" runat="server" CssClass="timesblock" 
-        meta:resourcekey="pnlFlightTimesResource1">
+    </div>
+    <div class="timesblock">
         <div class="header">
-            <asp:Localize ID="locTimesHeader" runat="server" Text="Times" 
-                meta:resourcekey="locTimesHeaderResource1"></asp:Localize>
+            <asp:Localize ID="locLandingsHeader" runat="server" Text="<%$ Resources:LogbookEntry, HeaderApproachesLandings %>" />
         </div>
-        <div id="rowTimes1">
-            <div class="itemtimeleft">
-                <div id="divApproaches" class="itemlabel"><asp:Label ID="Label11" runat="server" 
-                        Text="Approaches" meta:resourcekey="Label11Resource1"></asp:Label>
-                    <uc14:mfbTooltip ID="mfbTooltip3" runat="server" BodyContent="<%$ Resources:LocalizedText, EditFlightApproachTooltip %>" />
-                </div>
-                <div class="itemdata">
-                    <uc7:mfbDecimalEdit ID="intApproaches" EditingMode="Integer" Width="40px" TabIndex="6" runat="server" />&nbsp;<asp:CheckBox 
-                        ID="ckHold" runat="server" Text="Hold" TabIndex="7" 
-                        meta:resourcekey="ckHoldResource1" />
+        <div class="itemtimeleft">
+            <div id="divApproaches" class="itemlabel"><asp:Label ID="Label11" runat="server" 
+                    Text="Approaches" meta:resourcekey="Label11Resource1"></asp:Label>
+                <uc14:mfbTooltip ID="mfbTooltip3" runat="server" BodyContent="<%$ Resources:LocalizedText, EditFlightApproachTooltip %>" />
+            </div>
+            <div class="itemdata">
+                <uc7:mfbDecimalEdit ID="intApproaches" EditingMode="Integer" Width="40px" TabIndex="6" runat="server" />&nbsp;<asp:CheckBox 
+                    ID="ckHold" runat="server" Text="Hold" TabIndex="7" 
+                    meta:resourcekey="ckHoldResource1" />
                     
-                </div>
             </div>
-            <div class="itemtimeright">
-                <div id="divLandings" class="itemlabel"><asp:Label ID="Label12" runat="server" 
-                        Text="Total Landings" meta:resourcekey="Label12Resource1"></asp:Label> 
-                    <asp:Label ID="lblShowLandingDetails" runat="server" CssClass="fineprint" 
-                        meta:resourcekey="lblShowLandingDetailsResource1"></asp:Label>
-                </div>
-                <div class="itemdata">
-                    <uc7:mfbDecimalEdit ID="intLandings" EditingMode="Integer" Width="40px" TabIndex="8" runat="server" />
-                    <asp:CustomValidator ID="valCheckFullStop" 
-                        OnServerValidate="CheckFullStopCount" runat="server" ErrorMessage="Total landings must be greater than or equal to the number of full stop landings"
-                        CssClass="error" Display="Dynamic" 
-                        meta:resourcekey="valCheckFullStopResource1"></asp:CustomValidator>
-                    <asp:Panel ID="pnlLandingDetails" runat="server" Height="0px" style="overflow:hidden;" meta:resourcekey="pnlLandingDetailsResource1">
-                        <div>
-                            <div class="itemtimeleft">
-                                <asp:Label ID="Label13" runat="server" Text="Full Stop (Day):" meta:resourcekey="Label13Resource1"></asp:Label>
-                            </div>
-                            <div class="itemdata">
-                                <uc7:mfbDecimalEdit ID="intFullStopLandings" EditingMode="Integer" Width="40px" TabIndex="9" runat="server" />
-                            </div>
-                        </div>
-                        <div>
-                            <div class="itemtimeleft">
-                                <asp:Label ID="Label14" runat="server" Text="Full Stop (Night):" meta:resourcekey="Label14Resource1"></asp:Label>
-                            </div>
-                            <div class="itemdata">
-                                <uc7:mfbDecimalEdit ID="intNightLandings" EditingMode="Integer" Width="40px" TabIndex="10" runat="server" />
-                            </div>
-                        </div>
-                    </asp:Panel>
-                </div>
-            </div>
-            <cc1:CollapsiblePanelExtender ID="cpeLandingDetails" runat="server" CollapsedSize="0"   
-                CollapseControlID="lblShowLandingDetails" 
-                ExpandControlID="lblShowLandingDetails" Collapsed="True" 
-                CollapsedText="<%$ Resources:LocalizedText, ClickToShowDetails %>" ExpandedText="<%$ Resources:LocalizedText, ClickToHideDetails %>" 
-                TargetControlID="pnlLandingDetails" TextLabelID="lblShowLandingDetails" 
-                Enabled="True"></cc1:CollapsiblePanelExtender>                
         </div>
-        <div id="rowTimes2">
-            <div class="itemtimeleft">
-                <div id="divXC" class="itemlabel"><asp:Label ID="Label15" runat="server" 
-                        Text="Cross-Country" meta:resourcekey="Label15Resource1"></asp:Label>
-                </div>
-                <div class="itemdata">
-                    <uc7:mfbDecimalEdit ID="decXC" Width="40px" TabIndex="11" runat="server" />
-                </div>
+        <div class="itemtimeright">
+            <div id="divLandings" class="itemlabel"><asp:Label ID="Label12" runat="server" 
+                    Text="Total Landings" meta:resourcekey="Label12Resource1"></asp:Label> 
             </div>
-            <div class="itemtimeright">
-                <div id="divNight" class="itemlabel"><asp:Label ID="Label16" runat="server" 
-                        Text="Night" meta:resourcekey="Label16Resource1"></asp:Label>
+            <div class="itemdata">
+                <uc7:mfbDecimalEdit ID="intLandings" EditingMode="Integer" Width="40px" TabIndex="8" runat="server" />
+                <asp:CustomValidator ID="valCheckFullStop" 
+                    OnServerValidate="CheckFullStopCount" runat="server" ErrorMessage="Total landings must be greater than or equal to the number of full stop landings"
+                    CssClass="error" Display="Dynamic" 
+                    meta:resourcekey="valCheckFullStopResource1"></asp:CustomValidator>
+            </div>
+        </div>
+        <div class="itemtimeright">
+            <div>
+                <div class="itemlabel">
+                    <asp:Label ID="Label13" runat="server" Text="Full Stop (Day):" meta:resourcekey="Label13Resource1"></asp:Label>
                 </div>
                 <div class="itemdata">
-                    <uc7:mfbDecimalEdit ID="decNight" Width="40px" TabIndex="12" runat="server" />
+                    <uc7:mfbDecimalEdit ID="intFullStopLandings" EditingMode="Integer" Width="40px" TabIndex="9" runat="server" />
                 </div>
             </div>
         </div>
-        <div id="rowTimes3">
-            <div class="itemtimeleft">
-                <div id="divSimIFR" class="itemlabel"><asp:Label ID="Label17" runat="server" 
-                        Text="Simulated Instrument" meta:resourcekey="Label17Resource1"></asp:Label>
+        <div class="itemtimeright">
+            <div>
+                <div class="itemlabel">
+                    <asp:Label ID="Label14" runat="server" Text="Full Stop (Night):" meta:resourcekey="Label14Resource1"></asp:Label>
                 </div>
                 <div class="itemdata">
-                    <uc7:mfbDecimalEdit ID="decSimulatedIFR" Width="40px" TabIndex="13" runat="server" />
-                </div>
-            </div>
-            <div class="itemtimeright">
-                <div id="divIMC" class="itemlabel"><asp:Label ID="Label18" runat="server" 
-                        Text="IMC" meta:resourcekey="Label18Resource1"></asp:Label>
-                </div>
-                <div class="itemdata">
-                    <uc7:mfbDecimalEdit ID="decIMC"  Width="40px" TabIndex="14" runat="server" />
+                    <uc7:mfbDecimalEdit ID="intNightLandings" EditingMode="Integer" Width="40px" TabIndex="10" runat="server" />
                 </div>
             </div>
         </div>
-        <div id="rowTimes4">
-            <div class="itemtimeleft">
-                <div id="divGroundSim" class="itemlabel"><asp:Label ID="Label19" runat="server" 
-                        Text="Ground Sim" meta:resourcekey="Label19Resource1"></asp:Label>
-                </div>
-                <div class="itemdata">
-                    <uc7:mfbDecimalEdit ID="decGrndSim" Width="40px" TabIndex="15" runat="server" />
-                </div>
+    </div>
+    <div class="timesblock">
+        <div class="header">
+            <asp:Localize ID="locTimesHeader" runat="server" Text="<%$ Resources:LogbookEntry, HeaderTimes %>" />
+        </div>
+        <div class="itemtimeleft">
+            <div id="divXC" class="itemlabel"><asp:Label ID="Label15" runat="server" 
+                    Text="Cross-Country" meta:resourcekey="Label15Resource1"></asp:Label>
             </div>
-            <div class="itemtimeright">
-                <div id="divDual" class="itemlabel"><asp:Label ID="Label20" runat="server" 
-                        Text="Dual" meta:resourcekey="Label20Resource1"></asp:Label>
-                </div>
-                <div class="itemdata">
-                    <uc7:mfbDecimalEdit ID="decDual" Width="40px" TabIndex="16" runat="server" />
-                </div>
+            <div class="itemdata">
+                <uc7:mfbDecimalEdit ID="decXC" Width="40px" TabIndex="11" runat="server" />
             </div>
         </div>
-        <div id="rowTimes5">
-            <div class="itemtimeleft" id="divCFI" runat="server">
-                <div class="itemlabel"><asp:Label ID="Label21" runat="server" 
-                        Text="CFI (Instructor)" meta:resourcekey="Label21Resource1"></asp:Label>
-                </div>
-                <div class="itemdata">
-                    <uc7:mfbDecimalEdit ID="decCFI" Width="40px" TabIndex="17" runat="server" />
-                </div>
+        <div class="itemtimeright">
+            <div id="divNight" class="itemlabel"><asp:Label ID="Label16" runat="server" 
+                    Text="Night" meta:resourcekey="Label16Resource1"></asp:Label>
             </div>
-            <div class="itemtimeright" id="divSIC" runat="server">
-                <div id="div1" class="itemlabel"><asp:Label ID="Label22" runat="server" 
-                        Text="SIC (Second in Command)" meta:resourcekey="Label22Resource1"></asp:Label>
-                </div>
-                <div class="itemdata">
-                    <uc7:mfbDecimalEdit ID="decSIC" Width="40px" TabIndex="18" runat="server" />
-                </div>
-            </div>
-        </div>        
-        <div id="rowTimes6">
-            <div class="itemtimeleft">
-                <div id="divPIC" class="itemlabel"><asp:Label ID="Label23" runat="server" 
-                        Text="PIC" meta:resourcekey="Label23Resource1"></asp:Label>
-                </div>
-                <div class="itemdata">
-                    <uc7:mfbDecimalEdit ID="decPIC" Width="40px" TabIndex="19" runat="server" />
-                </div>
-            </div>
-            <div class="itemtimeright">
-                <div id="divTotal" class="itemlabel"><asp:Label ID="Label24" runat="server" 
-                        Text="Total Time" meta:resourcekey="Label24Resource1"></asp:Label>
-                </div>
-                <div class="itemdata">
-                    <uc7:mfbDecimalEdit ID="decTotal" Width="40px" TabIndex="20" runat="server" /> 
-                </div>
+            <div class="itemdata">
+                <uc7:mfbDecimalEdit ID="decNight" Width="40px" TabIndex="12" runat="server" />
             </div>
         </div>
-    </asp:Panel>
+        <div class="itemtimeleft">
+            <div id="divSimIFR" class="itemlabel"><asp:Label ID="Label17" runat="server" 
+                    Text="Simulated Instrument" meta:resourcekey="Label17Resource1"></asp:Label>
+            </div>
+            <div class="itemdata">
+                <uc7:mfbDecimalEdit ID="decSimulatedIFR" Width="40px" TabIndex="13" runat="server" />
+            </div>
+        </div>
+        <div class="itemtimeright">
+            <div id="divIMC" class="itemlabel"><asp:Label ID="Label18" runat="server" 
+                    Text="IMC" meta:resourcekey="Label18Resource1"></asp:Label>
+            </div>
+            <div class="itemdata">
+                <uc7:mfbDecimalEdit ID="decIMC"  Width="40px" TabIndex="14" runat="server" />
+            </div>
+        </div>
+        <div class="itemtimeleft">
+            <div id="divGroundSim" class="itemlabel"><asp:Label ID="Label19" runat="server" 
+                    Text="Ground Sim" meta:resourcekey="Label19Resource1"></asp:Label>
+            </div>
+            <div class="itemdata">
+                <uc7:mfbDecimalEdit ID="decGrndSim" Width="40px" TabIndex="15" runat="server" />
+            </div>
+        </div>
+        <div class="itemtimeright">
+            <div id="divDual" class="itemlabel"><asp:Label ID="Label20" runat="server" 
+                    Text="Dual" meta:resourcekey="Label20Resource1"></asp:Label>
+            </div>
+            <div class="itemdata">
+                <uc7:mfbDecimalEdit ID="decDual" Width="40px" TabIndex="16" runat="server" />
+            </div>
+        </div>
+        <div class="itemtimeleft">
+            <div class="itemlabel"><asp:Label ID="Label21" runat="server" 
+                    Text="CFI (Instructor)" meta:resourcekey="Label21Resource1"></asp:Label>
+            </div>
+            <div class="itemdata">
+                <uc7:mfbDecimalEdit ID="decCFI" Width="40px" TabIndex="17" runat="server" />
+            </div>
+        </div>
+        <div class="itemtimeright">
+            <div id="div1" class="itemlabel"><asp:Label ID="Label22" runat="server" 
+                    Text="SIC (Second in Command)" meta:resourcekey="Label22Resource1"></asp:Label>
+            </div>
+            <div class="itemdata">
+                <uc7:mfbDecimalEdit ID="decSIC" Width="40px" TabIndex="18" runat="server" />
+            </div>
+        </div>
+        <div class="itemtimeleft">
+            <div id="divPIC" class="itemlabel"><asp:Label ID="Label23" runat="server" 
+                    Text="PIC" meta:resourcekey="Label23Resource1"></asp:Label>
+            </div>
+            <div class="itemdata">
+                <uc7:mfbDecimalEdit ID="decPIC" Width="40px" TabIndex="19" runat="server" />
+            </div>
+        </div>
+        <div class="itemtimeright">
+            <div id="divTotal" class="itemlabel"><asp:Label ID="Label24" runat="server" 
+                    Text="Total Time" meta:resourcekey="Label24Resource1"></asp:Label>
+            </div>
+            <div class="itemdata">
+                <uc7:mfbDecimalEdit ID="decTotal" Width="40px" TabIndex="20" runat="server" /> 
+            </div>
+        </div>
+    </div>
     <div id="rowTimes7" class="fullblock">
         <asp:MultiView ID="mvPropEdit" runat="server" ActiveViewIndex="0">
             <asp:View ID="vwPropSet" runat="server">

--- a/MyFlightbook.Web/Controls/mfbEditFlight.ascx.designer.cs
+++ b/MyFlightbook.Web/Controls/mfbEditFlight.ascx.designer.cs
@@ -22,15 +22,6 @@ public partial class Controls_mfbEditFlight
     protected global::System.Web.UI.WebControls.Panel pnlContainer;
 
     /// <summary>
-    /// pnlFlightInfo control.
-    /// </summary>
-    /// <remarks>
-    /// Auto-generated field.
-    /// To modify move field declaration from designer file to code-behind file.
-    /// </remarks>
-    protected global::System.Web.UI.WebControls.Panel pnlFlightInfo;
-
-    /// <summary>
     /// lblSectionGeneralInfo control.
     /// </summary>
     /// <remarks>
@@ -193,22 +184,13 @@ public partial class Controls_mfbEditFlight
     protected global::System.Web.UI.WebControls.TextBox txtComments;
 
     /// <summary>
-    /// pnlFlightTimes control.
+    /// locLandingsHeader control.
     /// </summary>
     /// <remarks>
     /// Auto-generated field.
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
-    protected global::System.Web.UI.WebControls.Panel pnlFlightTimes;
-
-    /// <summary>
-    /// locTimesHeader control.
-    /// </summary>
-    /// <remarks>
-    /// Auto-generated field.
-    /// To modify move field declaration from designer file to code-behind file.
-    /// </remarks>
-    protected global::System.Web.UI.WebControls.Localize locTimesHeader;
+    protected global::System.Web.UI.WebControls.Localize locLandingsHeader;
 
     /// <summary>
     /// Label11 control.
@@ -256,15 +238,6 @@ public partial class Controls_mfbEditFlight
     protected global::System.Web.UI.WebControls.Label Label12;
 
     /// <summary>
-    /// lblShowLandingDetails control.
-    /// </summary>
-    /// <remarks>
-    /// Auto-generated field.
-    /// To modify move field declaration from designer file to code-behind file.
-    /// </remarks>
-    protected global::System.Web.UI.WebControls.Label lblShowLandingDetails;
-
-    /// <summary>
     /// intLandings control.
     /// </summary>
     /// <remarks>
@@ -281,15 +254,6 @@ public partial class Controls_mfbEditFlight
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::System.Web.UI.WebControls.CustomValidator valCheckFullStop;
-
-    /// <summary>
-    /// pnlLandingDetails control.
-    /// </summary>
-    /// <remarks>
-    /// Auto-generated field.
-    /// To modify move field declaration from designer file to code-behind file.
-    /// </remarks>
-    protected global::System.Web.UI.WebControls.Panel pnlLandingDetails;
 
     /// <summary>
     /// Label13 control.
@@ -328,13 +292,13 @@ public partial class Controls_mfbEditFlight
     protected global::Controls_mfbDecimalEdit intNightLandings;
 
     /// <summary>
-    /// cpeLandingDetails control.
+    /// locTimesHeader control.
     /// </summary>
     /// <remarks>
     /// Auto-generated field.
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
-    protected global::AjaxControlToolkit.CollapsiblePanelExtender cpeLandingDetails;
+    protected global::System.Web.UI.WebControls.Localize locTimesHeader;
 
     /// <summary>
     /// Label15 control.
@@ -445,15 +409,6 @@ public partial class Controls_mfbEditFlight
     protected global::Controls_mfbDecimalEdit decDual;
 
     /// <summary>
-    /// divCFI control.
-    /// </summary>
-    /// <remarks>
-    /// Auto-generated field.
-    /// To modify move field declaration from designer file to code-behind file.
-    /// </remarks>
-    protected global::System.Web.UI.HtmlControls.HtmlGenericControl divCFI;
-
-    /// <summary>
     /// Label21 control.
     /// </summary>
     /// <remarks>
@@ -470,15 +425,6 @@ public partial class Controls_mfbEditFlight
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::Controls_mfbDecimalEdit decCFI;
-
-    /// <summary>
-    /// divSIC control.
-    /// </summary>
-    /// <remarks>
-    /// Auto-generated field.
-    /// To modify move field declaration from designer file to code-behind file.
-    /// </remarks>
-    protected global::System.Web.UI.HtmlControls.HtmlGenericControl divSIC;
 
     /// <summary>
     /// Label22 control.

--- a/MyFlightbook.Web/Controls/mfbEditProp.ascx
+++ b/MyFlightbook.Web/Controls/mfbEditProp.ascx
@@ -1,11 +1,11 @@
-﻿    <%@ Control Language="C#" AutoEventWireup="true" Codebehind="mfbEditProp.ascx.cs" Inherits="Controls_mfbEditProp" %>
+﻿<%@ Control Language="C#" AutoEventWireup="true" Codebehind="mfbEditProp.ascx.cs" Inherits="Controls_mfbEditProp" %>
 <%@ Register Assembly="AjaxControlToolkit" Namespace="AjaxControlToolkit" TagPrefix="asp" %>
 <%@ Register src="mfbDateTime.ascx" tagname="mfbDateTime" tagprefix="uc1" %>
 <%@ Register src="mfbDecimalEdit.ascx" tagname="mfbDecimalEdit" tagprefix="uc2" %>
 <%@ Register src="mfbTypeInDate.ascx" tagname="mfbTypeInDate" tagprefix="uc4" %>
 <%@ Register src="mfbTooltip.ascx" tagname="mfbTooltip" tagprefix="uc3" %>
 <div class="propItemFlow">
-    <asp:Label ID="lblPropName" runat="server" EnableViewState="false"></asp:Label> <uc3:mfbTooltip ID="mfbTooltip" runat="server" EnableViewState="false" />
+    <asp:Label ID="lblPropName" runat="server" CssClass="itemlabel" EnableViewState="false"></asp:Label> <uc3:mfbTooltip ID="mfbTooltip" runat="server" EnableViewState="false" />
     <br />
     <asp:MultiView ID="mvProp" runat="server">
         <asp:View ID="vwDecimal" runat="server">

--- a/MyFlightbook.Web/Controls/mfbEditPropSet.ascx
+++ b/MyFlightbook.Web/Controls/mfbEditPropSet.ascx
@@ -24,7 +24,14 @@
             </Triggers>
             <ContentTemplate>
                 <div style="margin-bottom: 3px;">
-                    <div><asp:Label ID="lblAddPrompt" runat="server" Text="<%$ Resources:LogbookEntry, propAdditionalPropertiesPrompt %>"></asp:Label></div>
+                    <div>
+                        <asp:Label ID="lblAddPrompt" runat="server" CssClass="itemlabel" Text="<%$ Resources:LogbookEntry, propAdditionalPropertiesPrompt %>"></asp:Label>
+                        <span class="fineprint">(<asp:HyperLink ID="lnkContactMe" 
+                            NavigateUrl="~/Public/ContactMe.aspx" Target="_blank" runat="server" 
+                            Text="<%$ Resources:LogbookEntry, NewPropertyPrompt1 %>"></asp:HyperLink>
+                        <asp:Label ID="lblContactUsRemainder" runat="server" 
+                            Text="<%$ Resources:LogbookEntry, NewPropertyPrompt2 %>"></asp:Label>)</span>
+                    </div>
                     <table>
                         <tr style="vertical-align:top">
                             <td>
@@ -51,11 +58,6 @@
                             <td>
                         </tr>
                     </table>
-                    <div class="fineprint">(<asp:HyperLink ID="lnkContactMe" 
-                        NavigateUrl="~/Public/ContactMe.aspx" Target="_blank" runat="server" 
-                        Text="<%$ Resources:LogbookEntry, NewPropertyPrompt1 %>"></asp:HyperLink>
-                    <asp:Label ID="lblContactUsRemainder" runat="server" 
-                        Text="<%$ Resources:LogbookEntry, NewPropertyPrompt2 %>"></asp:Label>)</div>
                 </div>
                 <asp:Panel ID="pnlProps" runat="server" CssClass="propItemContainer" ScrollBars="Auto">
                     <asp:PlaceHolder ID="plcHolderProps" runat="server">

--- a/MyFlightbook.Web/Controls/mfbEditPropSet.ascx.cs
+++ b/MyFlightbook.Web/Controls/mfbEditPropSet.ascx.cs
@@ -261,8 +261,6 @@ public partial class Controls_mfbEditPropSet : System.Web.UI.UserControl
         ep.CrossFillSourceClientID = CrossFillSourceClientID;
         ep.ID = IDForPropType(cfp.PropertyType);
         ep.FlightProperty = cfp;
-
-        pnlProps.CssClass = (plcHolderProps.Controls.Count > 10) ? "propItemContainerOverflow" : "propItemContainer";
     }
 
     /// <summary>

--- a/MyFlightbook.Web/Controls/mfbEditPropSet.ascx.designer.cs
+++ b/MyFlightbook.Web/Controls/mfbEditPropSet.ascx.designer.cs
@@ -31,6 +31,24 @@ public partial class Controls_mfbEditPropSet
     protected global::System.Web.UI.WebControls.Label lblAddPrompt;
 
     /// <summary>
+    /// lnkContactMe control.
+    /// </summary>
+    /// <remarks>
+    /// Auto-generated field.
+    /// To modify move field declaration from designer file to code-behind file.
+    /// </remarks>
+    protected global::System.Web.UI.WebControls.HyperLink lnkContactMe;
+
+    /// <summary>
+    /// lblContactUsRemainder control.
+    /// </summary>
+    /// <remarks>
+    /// Auto-generated field.
+    /// To modify move field declaration from designer file to code-behind file.
+    /// </remarks>
+    protected global::System.Web.UI.WebControls.Label lblContactUsRemainder;
+
+    /// <summary>
     /// imgSearch control.
     /// </summary>
     /// <remarks>
@@ -92,24 +110,6 @@ public partial class Controls_mfbEditPropSet
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
     protected global::Controls_mfbSelectTemplates mfbSelectTemplates;
-
-    /// <summary>
-    /// lnkContactMe control.
-    /// </summary>
-    /// <remarks>
-    /// Auto-generated field.
-    /// To modify move field declaration from designer file to code-behind file.
-    /// </remarks>
-    protected global::System.Web.UI.WebControls.HyperLink lnkContactMe;
-
-    /// <summary>
-    /// lblContactUsRemainder control.
-    /// </summary>
-    /// <remarks>
-    /// Auto-generated field.
-    /// To modify move field declaration from designer file to code-behind file.
-    /// </remarks>
-    protected global::System.Web.UI.WebControls.Label lblContactUsRemainder;
 
     /// <summary>
     /// pnlProps control.

--- a/MyFlightbook.Web/Controls/mfbFlightInfo.ascx
+++ b/MyFlightbook.Web/Controls/mfbFlightInfo.ascx
@@ -6,6 +6,8 @@
 <%@ Register src="mfbTimeZone.ascx" tagname="mfbTimeZone" tagprefix="uc1" %>
 <%@ Register src="popmenu.ascx" tagname="popmenu" tagprefix="uc4" %>
 <%@ Register Src="~/Controls/AutofillOptionsChooser.ascx" TagPrefix="uc1" TagName="AutofillOptionsChooser" %>
+<%@ Register Src="~/Controls/mfbTooltip.ascx" TagPrefix="uc1" TagName="mfbTooltip" %>
+
 
 <asp:Panel ID="pnlFlightInfo" runat="server">
     <asp:Panel ID="pnlHobbs" runat="server" CssClass="flightinfoitem">
@@ -17,7 +19,7 @@
             </tr>
             <tr>
                 <td>
-                    <asp:Label ID="lblHobbsStart" runat="server" Text="<%$ Resources:LogbookEntry, ShortStart %>"></asp:Label>
+                    <asp:Label ID="lblHobbsStart" CssClass="itemlabel" runat="server" Text="<%$ Resources:LogbookEntry, ShortStart %>"></asp:Label>
                 </td>
                 <td>
                     <uc3:mfbDecimalEdit ID="decHobbsStart" runat="server" Width="70" />
@@ -26,7 +28,7 @@
             </tr>
             <tr>
                 <td>
-                    <asp:Label ID="lblHobbsEnd" runat="server" Text="<%$ Resources:LogbookEntry, ShortEnd %>"></asp:Label>
+                    <asp:Label ID="lblHobbsEnd" runat="server" CssClass="itemlabel" Text="<%$ Resources:LogbookEntry, ShortEnd %>"></asp:Label>
                 </td>
                 <td>
                     <uc3:mfbDecimalEdit ID="decHobbsEnd" runat="server" Width="70" />
@@ -43,7 +45,7 @@
             </tr>
             <tr>
                 <td>
-                    <asp:Label ID="lblEngineStart" runat="server" Text="<%$ Resources:LogbookEntry, ShortStart %>"></asp:Label>
+                    <asp:Label ID="lblEngineStart" CssClass="itemlabel" runat="server" Text="<%$ Resources:LogbookEntry, ShortStart %>"></asp:Label>
                 </td>
                 <td>
                     <uc2:mfbDateTime ID="mfbEngineStart" runat="server" />&nbsp;&nbsp;&nbsp;
@@ -51,7 +53,7 @@
             </tr>
             <tr>
                 <td>
-                    <asp:Label ID="lblEngineEnd" runat="server" Text="<%$ Resources:LogbookEntry, ShortEnd %>"></asp:Label>
+                    <asp:Label ID="lblEngineEnd" CssClass="itemlabel" runat="server" Text="<%$ Resources:LogbookEntry, ShortEnd %>"></asp:Label>
                 </td>
                 <td>
                     <uc2:mfbDateTime ID="mfbEngineEnd" runat="server" />
@@ -68,7 +70,7 @@
             </tr>
             <tr>
                 <td>
-                    <asp:Label ID="lblFlightStart" runat="server" Text="<%$ Resources:LogbookEntry, ShortStart %>"></asp:Label>
+                    <asp:Label ID="lblFlightStart" CssClass="itemlabel" runat="server" Text="<%$ Resources:LogbookEntry, ShortStart %>"></asp:Label>
                 </td>
                 <td>
                     <uc2:mfbDateTime ID="mfbFlightStart" runat="server" />&nbsp;&nbsp;&nbsp;
@@ -76,7 +78,7 @@
             </tr>
             <tr>
                 <td>
-                    <asp:Label ID="lblFlightEnd" runat="server" Text="<%$ Resources:LogbookEntry, ShortEnd %>"></asp:Label>
+                    <asp:Label ID="lblFlightEnd" CssClass="itemlabel" runat="server" Text="<%$ Resources:LogbookEntry, ShortEnd %>"></asp:Label>
                 </td>
                 <td>
                     <uc2:mfbDateTime ID="mfbFlightEnd" runat="server" />
@@ -125,8 +127,8 @@
         <table>
             <tr class="itemlabel">
                 <td style="max-width: 600px">
-                    <asp:Label ID="lblAutoFill" Font-Bold="True" runat="server" Text="<%$ Resources:LogbookEntry, AutoFillPrompt %>"></asp:Label><br />
-                    <asp:Label ID="lblAutoFillDesc" runat="server" Text="<%$ Resources:LogbookEntry, AutoFillDescription %>"></asp:Label>
+                    <asp:Label ID="lblAutoFill" Font-Bold="True" runat="server" Text="<%$ Resources:LogbookEntry, AutoFillPrompt %>"></asp:Label>
+                    <uc1:mfbtooltip runat="server" id="mfbTooltip" BodyContent="<%$ Resources:LogbookEntry, AutoFillDescription %>" />
                 </td>
                 <td><asp:Button ID="btnAutoFill" runat="server" onclick="onAutofill" 
                         Text="<%$ Resources:LogbookEntry, AutoFill %>"></asp:Button></td>

--- a/MyFlightbook.Web/Controls/mfbFlightInfo.ascx.designer.cs
+++ b/MyFlightbook.Web/Controls/mfbFlightInfo.ascx.designer.cs
@@ -328,13 +328,13 @@ public partial class Controls_mfbFlightInfo
     protected global::System.Web.UI.WebControls.Label lblAutoFill;
 
     /// <summary>
-    /// lblAutoFillDesc control.
+    /// mfbTooltip control.
     /// </summary>
     /// <remarks>
     /// Auto-generated field.
     /// To modify move field declaration from designer file to code-behind file.
     /// </remarks>
-    protected global::System.Web.UI.WebControls.Label lblAutoFillDesc;
+    protected global::Controls_mfbTooltip mfbTooltip;
 
     /// <summary>
     /// btnAutoFill control.

--- a/MyFlightbook.Web/MasterPage.master.cs
+++ b/MyFlightbook.Web/MasterPage.master.cs
@@ -196,7 +196,7 @@ namespace MyFlightbook.Web
                 lnkPrivacy.Text = String.Format(CultureInfo.CurrentCulture, Resources.LocalizedText.PrivacyPolicyHeader, Branding.CurrentBrand.AppName);
 
                 lnkAppleIcon.Href = ResolveUrl("~/images/apple-touch-icon.png");
-                cssMain.Href = "~/Public/stylesheet.css?v=22".ToAbsoluteURL(Request).ToString();    // to enable forced reload
+                cssMain.Href = "~/Public/stylesheet.css?v=23".ToAbsoluteURL(Request).ToString();    // to enable forced reload
                 cssMobile.Visible = mfbHeader.IsMobile = MfbFooter.IsMobile = IsMobileSession();
                 cssMobile.Href = ResolveUrl("~/Public/CSS/MobileSheet.css?v=8");
                 string szStyle = Branding.CurrentBrand.StyleSheet;

--- a/MyFlightbook.Web/Member/EditProfile.aspx
+++ b/MyFlightbook.Web/Member/EditProfile.aspx
@@ -298,19 +298,7 @@
                                 </asp:RadioButtonList>
                                 <div><asp:Label ID="lblFieldsToShow" runat="server" Font-Bold="True" Text="Show the following for flights:" meta:resourcekey="lblFieldsToShowResource2"></asp:Label></div>
                                 <table> <!-- table here is to match layout of radiobuttonlist above -->
-                                    <tr>
-                                        <td>
-                                            <asp:CheckBox ID="ckTrackCFITime" runat="server" Text="CFI Time" 
-                                                ValidationGroup="valPrefs" meta:resourcekey="ckTrackCFITimeResource1" />
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                            <asp:CheckBox ID="ckSIC" runat="server" Text="Second in Command (SIC) time" 
-                                                ValidationGroup="valPrefs" meta:resourcekey="ckSICResource1" />
-                                        </td>
-                                    </tr>
-                                    <tr>
+                                     <tr>
                                         <td>
                                             <asp:CheckBox ID="ckShowTimes" runat="server" 
                                                 Text="Hobbs time, flight times, and engine times for flights" 

--- a/MyFlightbook.Web/Member/EditProfile.aspx.cs
+++ b/MyFlightbook.Web/Member/EditProfile.aspx.cs
@@ -125,8 +125,6 @@ public partial class Member_EditProfile : System.Web.UI.Page
     private void InitFeaturePrefs()
     {
         ckShowTimes.Checked = m_pf.DisplayTimesByDefault;
-        ckSIC.Checked = m_pf.TracksSecondInCommandTime;
-        ckTrackCFITime.Checked = m_pf.IsInstructor;
         ckUseArmyCurrency.Checked = m_pf.UsesArmyCurrency;
         ckUse117DutyTime.Checked = m_pf.UsesFAR117DutyTime;
         rbl117Rules.SelectedIndex = m_pf.UsesFAR117DutyTimeAllFlights ? 1 : 0;
@@ -399,8 +397,6 @@ public partial class Member_EditProfile : System.Web.UI.Page
     protected void btnUpdateLocalPrefs_Click(object sender, EventArgs e)
     {
         m_pf.DisplayTimesByDefault = ckShowTimes.Checked;
-        m_pf.TracksSecondInCommandTime = ckSIC.Checked;
-        m_pf.IsInstructor = ckTrackCFITime.Checked;
         m_pf.UsesHHMM = (rblTimeEntryPreference.SelectedIndex > 0);
         m_pf.UsesUTCDateOfFlight = (rblDateEntryPreferences.SelectedIndex > 0);
         m_pf.PreferredTimeZoneID = prefTimeZone.SelectedTimeZoneId;

--- a/MyFlightbook.Web/Member/EditProfile.aspx.designer.cs
+++ b/MyFlightbook.Web/Member/EditProfile.aspx.designer.cs
@@ -805,24 +805,6 @@ public partial class Member_EditProfile
     protected global::System.Web.UI.WebControls.Label lblFieldsToShow;
 
     /// <summary>
-    /// ckTrackCFITime control.
-    /// </summary>
-    /// <remarks>
-    /// Auto-generated field.
-    /// To modify move field declaration from designer file to code-behind file.
-    /// </remarks>
-    protected global::System.Web.UI.WebControls.CheckBox ckTrackCFITime;
-
-    /// <summary>
-    /// ckSIC control.
-    /// </summary>
-    /// <remarks>
-    /// Auto-generated field.
-    /// To modify move field declaration from designer file to code-behind file.
-    /// </remarks>
-    protected global::System.Web.UI.WebControls.CheckBox ckSIC;
-
-    /// <summary>
     /// ckShowTimes control.
     /// </summary>
     /// <remarks>

--- a/MyFlightbook.Web/Public/CSS/MobileSheet.css
+++ b/MyFlightbook.Web/Public/CSS/MobileSheet.css
@@ -8,19 +8,6 @@ h1 {
     font-size:10pt;
 }
 
-/* Overrides for logbook entry to enable a vertical layout */
-.itemtimeleft
-{
-    clear:both;
-    width: 300px;
-}
-
-/* item on the right of a left-right layout */
-.itemtimeright
-{
-    clear:both;
-}
-
 /* Basic info about the flight */
 .flightinfoblock
 {
@@ -55,47 +42,6 @@ h1 {
 .fullblock
 {
     width:auto;
-}
-
-.itemdata
-{
-    display: inline;
-    clear:both;
-    font-size:8pt;
-}
-
-/* item labels in both left and right times */
-.itemtimeleft .itemlabel, .itemtimeright .itemlabel, .flightinfoblock .itemlabel, .itemtime .itemlabel
-{
-    /* display: inline; */
-    float: left;
-    text-align: right;
-    width: 100px;
-    padding-right: 5px;
-    vertical-align: baseline;
-}
-
-/* flight-info items */
-.flightinfoitem
-{
-    float: none;
-}
-
-/* PropertyEditing*/
-.propItemFlow
-{
-    width: 280px;
-}
-
-.propItemContainer
-{
-    width: 310px;
-}
-
-.propItemContainerOverflow
-{
-    width: 310px;
-    height: 175px;
 }
 
 /* Header */

--- a/MyFlightbook.Web/Public/CSS/NightMode.css
+++ b/MyFlightbook.Web/Public/CSS/NightMode.css
@@ -66,6 +66,10 @@ p, div, h2, h3, topTab, a.topTab, a.topTab:visited, #menu-bar .topTab, #menu-bar
     background-color: #263238;
 }
 
+.header, .itemlabel {
+    color: #d8d8d8;
+}
+
 .headerBase, .headerBase a, .headerBase a:hover {
     color: white;
 }

--- a/MyFlightbook.Web/Public/StatsForMail.aspx.cs
+++ b/MyFlightbook.Web/Public/StatsForMail.aspx.cs
@@ -18,7 +18,7 @@ public partial class Public_StatsForMail : System.Web.UI.Page
     {
         if (!IsPostBack)
         {
-            cssRef.Href = "~/Public/Stylesheet.css?v=22".ToAbsoluteURL(Request.Url.Scheme, Branding.CurrentBrand.HostName, Request.Url.Port).ToString();
+            cssRef.Href = "~/Public/Stylesheet.css?v=23".ToAbsoluteURL(Request.Url.Scheme, Branding.CurrentBrand.HostName, Request.Url.Port).ToString();
             baseRef.Attributes["href"] = "~/Public/".ToAbsoluteURL(Request.Url.Scheme, Branding.CurrentBrand.HostName, Request.Url.Port).ToString();
             string szAuthKey = util.GetStringParam(Request, "k");
 

--- a/MyFlightbook.Web/Public/TotalsAndCurrencyEmail.aspx.cs
+++ b/MyFlightbook.Web/Public/TotalsAndCurrencyEmail.aspx.cs
@@ -44,7 +44,7 @@ public partial class Public_TotalsAndCurrencyEmail : System.Web.UI.Page
 
         if (!IsPostBack)
         {
-            cssRef.Href = "~/Public/Stylesheet.css?v=22".ToAbsoluteURL(Request.Url.Scheme, Branding.CurrentBrand.HostName, Request.Url.Port).ToString();
+            cssRef.Href = "~/Public/Stylesheet.css?v=23".ToAbsoluteURL(Request.Url.Scheme, Branding.CurrentBrand.HostName, Request.Url.Port).ToString();
             baseRef.Attributes["href"] = "~/Public/".ToAbsoluteURL(Request.Url.Scheme, Branding.CurrentBrand.HostName, Request.Url.Port).ToString();
 
             string szAuthKey = util.GetStringParam(Request, "k");

--- a/MyFlightbook.Web/Public/stylesheet.css
+++ b/MyFlightbook.Web/Public/stylesheet.css
@@ -105,6 +105,12 @@ H4
     margin-right: auto;
 }
 
+input[type=text],input[type=password], input[type=number],input[type=email] {
+    border-radius: 5px;
+    border: 1px solid #a0a0a0;
+    padding: 2px;
+}
+
 /* Header */
 #headerBar
 {
@@ -160,14 +166,15 @@ H4
 }
 
 /* Data entry form */
-.header
-{
+.header {
     font-weight: bold;
-    border-bottom: black 1px solid;
+    color: #263238;
+    border-bottom: 1px solid darkgray;
+    margin-bottom: 2px;
 }
-.itemlabel
-{
+.itemlabel {
     font-size: 9pt;
+    color: /* #00bcd4 */ #263238;
 }
 
 .logbookForm
@@ -908,45 +915,32 @@ a img
 
 /* Edit Flight */
 /* item on the left of a left-right layout */
-.itemtimeleft
-{
-    display: inline;
-    float: left;
-    clear: left;
+.itemtimeleft, .itemtimeright {
+    display: inline-block;
     vertical-align: bottom;
     width: 150px;
-    padding: 3px;
-}
-
-/* item on the right of a left-right layout */
-.itemtimeright
-{
-    display: inline;
-    float: left;
-    clear: right;
-    vertical-align: bottom;
-    padding: 3px;
+    margin-left: 5px;
+    margin-right: 5px;
 }
 
 /* item with no particular left/right layout */
 .itemtime
 {
     padding: 3px;
+    display: inline-block;
+    width: 250px;
+    vertical-align: top;
 }
 
 /* Basic info about the flight */
 .flightinfoblock
 {
-    float: left;
-    clear: left;
     padding: 3px;
 }
 
 /* the various times for the flight */
 .timesblock
 {
-    float: left;
-    clear: right;
     padding: 3px;
 }
 
@@ -959,11 +953,9 @@ a img
 }
 
 /* item labels in both left and right times */
-.itemtimeleft .itemlabel, .itemtimeright .itemlabel, .flightinfoblock .itemlabel
-{
+.itemtimeleft .itemlabel, .itemtimeright .itemlabel, .flightinfoblock .itemlabel {
     padding: 0px, 0px, 0px, 0px;
     display: block;
-    clear: both;
 }
 
 /* flight-info items */
@@ -976,18 +968,18 @@ a img
 .propItemFlow
 {
     display:inline-block;
-    vertical-align:middle;
-    width: 280px;
-    height: 37px;
+    vertical-align:bottom;
+    width: 150px;
     padding-top: 1px;
     padding-bottom: 2px;
+    margin-left: 5px; margin-right: 5px;
 }
 
 .propItemContainer
 {
-    width: 600px;
     padding: 3px;
     border-style: none;
+    max-height: 200px;
 }
 
 .propItemContainerOverflow


### PR DESCRIPTION
 * More fluid layout, with more inline-block for wrapping and more optimal screen usage.  Removed itemtimeleft/itemtimeright css classes
 * Always show full-stop landings, SIC, CFI (options around that removed)
 * condensed some verbage (properties, autofill)
 * EditPropsetScrollbar is now handled strictly by the browser (no border)
 * Add styling to edit boxes (rounded corners, slightly grayed borders)