### PR TITLE
Adjust the FAR 61.109(a)(5)(ii) notes

### DIFF
--- a/MyFlightbook.Web/App_GlobalResources/MilestoneProgress.resx
+++ b/MyFlightbook.Web/App_GlobalResources/MilestoneProgress.resx
@@ -163,7 +163,7 @@
     <value>See FAR 61.110 for possible exceptions that may apply to you.  Night landings are assumed to have involved flight in the traffic pattern.</value>
   </data>
   <data name="NoteXCLandings" xml:space="preserve">
-    <value>Landings are assumed to have been at the listed airports.  The requirement for an operating control tower is NOT being enforced/checked here.</value>
+    <value>Landings are assumed to have been at the listed airports.</value>
   </data>
   <data name="NotMet" xml:space="preserve">
     <value>Not yet completed.</value>


### PR DESCRIPTION
Hey Eric,

I've never dealt with C# before, but I figured I'd elicit your feedback anyway just in case this is helpful. I can also just create an issue and delete this PR if you don't want outside contributions. I didn't realize this was FOSS and would love to contribute in a more substantive way in the future if possible (although I develop with a Mac, so I might have to dual boot Windows).

In the notes, a requirement of landing at a controlled airport as part of the 150nm XC is included, but this is a separate requirement (which is already included as **61.109(a)(5)(iii)**) and doesn't matter for this item. I couldn't suss out whether this line is used in other places, but it's a bit misleading since it's a requirement and might be helpful to add another data item with a new name _if it is_.

**Photo of site:**
<img width="1073" alt="Screen Shot 2020-12-23 at 11 15 30 AM" src="https://user-images.githubusercontent.com/8980594/103016669-6454bb80-4510-11eb-8e42-3109b887f575.png">

**Photo of FAR:**
<img width="821" alt="Screen Shot 2020-12-23 at 11 19 18 AM" src="https://user-images.githubusercontent.com/8980594/103016692-746c9b00-4510-11eb-8828-9969b5fc9b70.png">

Happy holidays and cheers for MyFlightbook!