### PR TITLE
Issue #813: allow flights that are ground-instruction to be signed by…

### DIFF
--- a/MyFlightbook.Web/AppCode/Flights/LogbookEntry.cs
+++ b/MyFlightbook.Web/AppCode/Flights/LogbookEntry.cs
@@ -341,6 +341,16 @@ namespace MyFlightbook
             get { return IsNewFlightID(FlightID); }
         }
 
+        /// <summary>
+        /// Returns true if the flight looks like it's strictly ground instruction
+        /// Useful for signing because ground instructors don't expire, so we can relax the requirement
+        /// for an expiration in those scenarios.
+        /// </summary>
+        public bool IsGroundOnly
+        {
+            get { return TotalFlightTime + PIC + SIC + Dual == 0 && CustomProperties.PropertyExistsWithID(CustomPropertyType.KnownProperties.IDPropGroundInstructionReceived); }
+        }
+
         public static Boolean IsNewFlightID(int idFlight)
         {
             return idFlight == LogbookEntry.idFlightNew || idFlight == LogbookEntry.idFlightNone || idFlight < 0;
@@ -1223,7 +1233,7 @@ namespace MyFlightbook
             if (!CanSignThisFlight(szCFIUsername, out string szErr))
                 throw new MyFlightbookException(szErr);
 
-            if (!pfCFI.CanSignFlights(out szErr))
+            if (!pfCFI.CanSignFlights(out szErr, IsGroundOnly))
                 throw new MyFlightbookException(szErr);
 
             DigitizedSignature = null;

--- a/MyFlightbook.Web/AppCode/UserAccounts/Profile.cs
+++ b/MyFlightbook.Web/AppCode/UserAccounts/Profile.cs
@@ -1437,10 +1437,9 @@ namespace MyFlightbook
         /// <summary>
         /// Determines if the named user is eligible to sign flights
         /// </summary>
-        /// <param name="szCFIUsername">The name of the potential signer</param>
         /// <param name="szError">The error that results</param>
         /// <returns>True if they can sign</returns>
-        public bool CanSignFlights(out string szError)
+        public bool CanSignFlights(out string szError, bool fIsGround)
         {
             szError = String.Empty;
             if (String.IsNullOrEmpty(Certificate))
@@ -1449,7 +1448,11 @@ namespace MyFlightbook
                 return false;
             }
 
-            if (CertificateExpiration.AddDays(1).CompareTo(DateTime.Now) < 0)
+            // Error to 
+            // (a) lack an expiration date UNLESS the flight is ground-only
+            // (b) have an expiration date in the past
+            if ((!CertificateExpiration.HasValue() && !fIsGround) || 
+                (CertificateExpiration.HasValue() && CertificateExpiration.AddDays(1).CompareTo(DateTime.Now) < 0))
             {
                 szError = Resources.SignOff.errSignExpiredCertificate;
                 return false;


### PR DESCRIPTION
… ground instructor

Don't require an expiration date if the flight appears to be ground-only.
Ground-only = (a) PIC+SIC+Dual+Total=0 (i.e., no flight time) and (b) flight contains ground-instruction-received property