### PR TITLE
Issue #1033: show flights that were ignored in ratings progress due t…

### DIFF
--- a/MyFlightbook.Web/AppCode/Flights/Ratings/CommRatings.cs
+++ b/MyFlightbook.Web/AppCode/Flights/Ratings/CommRatings.cs
@@ -143,8 +143,8 @@ namespace MyFlightbook.RatingsProgress
         protected MilestoneItem miMinPoweredInCategory { get; set; }
         protected MilestoneItem miPICMin { get; set; }
         protected MilestoneItem miPICMinCategory { get; set; }
-        protected MilestoneItem miPICMinXC { get; set; }
-        protected MilestoneItem miPICMinXCCategory { get; set; }
+        protected MilestoneItemXC miPICMinXC { get; set; }
+        protected MilestoneItemXC miPICMinXCCategory { get; set; }
         protected MilestoneItem miMinTraining { get; set; }
         protected MilestoneItem miMintrainingSimIMC { get; set; }
         protected MilestoneItem miMinTrainingSimIMCCategory { get; set; }
@@ -197,8 +197,8 @@ namespace MyFlightbook.RatingsProgress
             // 61.129 (a/b)(2)
             miPICMin = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.CommMinPIC, _minPIC), ResolvedFAR("(2)"), string.Empty, MilestoneItem.MilestoneType.Time, _minPIC);
             miPICMinCategory = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.CommMinPICInCategory, _minPICInCategory, szCategory), ResolvedFAR("(2)(i)"), string.Empty, MilestoneItem.MilestoneType.Time, _minPICInCategory);
-            miPICMinXC = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.CommMinPICXC, _minPICXC), ResolvedFAR("(2)(ii)"), string.Empty, MilestoneItem.MilestoneType.Time, _minPICXC);
-            miPICMinXCCategory = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.CommMinPICXCInCategory, _minPICXCInCategory, szCategory), ResolvedFAR("(2)(ii)"), string.Empty, MilestoneItem.MilestoneType.Time, _minPICXCInCategory);
+            miPICMinXC = new MilestoneItemXC(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.CommMinPICXC, _minPICXC), ResolvedFAR("(2)(ii)"), string.Empty, MilestoneItem.MilestoneType.Time, _minPICXC);
+            miPICMinXCCategory = new MilestoneItemXC(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.CommMinPICXCInCategory, _minPICXCInCategory, szCategory), ResolvedFAR("(2)(ii)"), string.Empty, MilestoneItem.MilestoneType.Time, _minPICXCInCategory);
 
             miDualAsPIC = new MilestoneItem("local - dual as PIC", ResolvedFAR("(2)"), string.Empty, MilestoneItem.MilestoneType.Time, _minSubstDualForPIC);
             miDualAsPICXC = new MilestoneItem("local - dual as PICXC", ResolvedFAR("(2)"), string.Empty, MilestoneItem.MilestoneType.Time, _minSubstDualForPIC);
@@ -367,6 +367,11 @@ namespace MyFlightbook.RatingsProgress
             AirportList al = AirportListOfRoutes.CloneSubset(cfr.Route, true);
             double distFromStart = al.MaxDistanceFromStartingAirport();
             decimal xc = distFromStart > MinXCDistanceForRating() ? cfr.XC : 0;
+            if (xc < cfr.XC)
+            {
+                miPICMinXC.AddIgnoredFlight(cfr);
+                miPICMinXCCategory.AddIgnoredFlight(cfr);
+            }
 
             decimal PIC = Math.Max(cfr.PIC, soloTime);
             decimal PICXC = Math.Min(PIC, xc);

--- a/MyFlightbook.Web/AppCode/Flights/Ratings/IFRRatings.cs
+++ b/MyFlightbook.Web/AppCode/Flights/Ratings/IFRRatings.cs
@@ -51,8 +51,8 @@ namespace MyFlightbook.RatingsProgress
     [Serializable]
     public abstract class IFR6165Base : MilestoneProgress
     {
-        protected MilestoneItem miMinXCTime { get; set; }
-        protected MilestoneItem miMinTimeInCategory { get; set; }
+        protected MilestoneItemXC miMinXCTime { get; set; }
+        protected MilestoneItemXC miMinTimeInCategory { get; set; }
         protected MilestoneItem miMinIMCTime { get; set; }
         protected MilestoneItemDecayable miMinIMCTestPrep { get; set; }
         protected MilestoneItem miIMCXC { get; set; }
@@ -110,8 +110,8 @@ namespace MyFlightbook.RatingsProgress
             }
 
             // 61.65(def)(1)
-            miMinXCTime = new MilestoneItem(Resources.MilestoneProgress.MinInstrumentPICXC, ResolvedFAR("(1)"), Resources.MilestoneProgress.NoteXCTime, MilestoneItem.MilestoneType.Time, 50.0M);
-            miMinTimeInCategory = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinInstrumentPICInCategory, szAircraftCategory), ResolvedFAR("(1)"), String.Empty, MilestoneItem.MilestoneType.Time, 10.0M);
+            miMinXCTime = new MilestoneItemXC(Resources.MilestoneProgress.MinInstrumentPICXC, ResolvedFAR("(1)"), Resources.MilestoneProgress.NoteXCTime, MilestoneItem.MilestoneType.Time, 50.0M);
+            miMinTimeInCategory = new MilestoneItemXC(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinInstrumentPICInCategory, szAircraftCategory), ResolvedFAR("(1)"), String.Empty, MilestoneItem.MilestoneType.Time, 10.0M);
 
             // 61.65(def)(2) - total instrument time
             miMinIMCTime = new MilestoneItem(Resources.MilestoneProgress.MinInstrumentTime, ResolvedFAR("(2)"), Branding.ReBrand(Resources.MilestoneProgress.NoteInstrumentTime), MilestoneItem.MilestoneType.Time, 40.0M);
@@ -164,6 +164,13 @@ namespace MyFlightbook.RatingsProgress
             miMinXCTime.AddEvent(XCPICTime);
             if (IsInMatchingCategory)
                 miMinTimeInCategory.AddEvent(XCPICTime);
+
+            // Determine ignored flights
+            if (XCPICTime < Math.Min(cfr.PIC, cfr.XC))
+            {
+                miMinXCTime.AddIgnoredFlight(cfr);
+                miMinTimeInCategory.AddIgnoredFlight(cfr);
+            }
 
             // 61.65(def)(2) - IMC time (total)
             miMinIMCTime.AddEvent(IMCTime);

--- a/MyFlightbook.Web/AppCode/Flights/Ratings/PPLRatings.cs
+++ b/MyFlightbook.Web/AppCode/Flights/Ratings/PPLRatings.cs
@@ -66,14 +66,14 @@ namespace MyFlightbook.RatingsProgress
         protected MilestoneItem miMinTime { get; set; }
         protected MilestoneItem miMinTraining { get; set; }
         protected MilestoneItem miMinSolo { get; set; }
-        protected MilestoneItem miMinDualXC { get; set; }
+        protected MilestoneItemXC miMinDualXC { get; set; }
         protected MilestoneItem miMinNightTime { get; set; }
-        protected MilestoneItem miMinXCNight { get; set; }
+        protected MilestoneItemXC miMinXCNight { get; set; }
         protected MilestoneItem miMinNightTO { get; set; }
         protected MilestoneItem miMinNightFSLandings { get; set; }
         protected MilestoneItem miMinSimIMC { get; set; }
         protected MilestoneItemDecayable miMinTestPrep { get; set; }
-        protected MilestoneItem miMinXCSolo { get; set; }
+        protected MilestoneItemXC miMinXCSolo { get; set; }
         protected MilestoneItem miMinXCDistance { get; set; }
         protected MilestoneItem miMinXCLandings { get; set; }
         protected MilestoneItem miMinSoloInType { get; set; }
@@ -238,11 +238,11 @@ namespace MyFlightbook.RatingsProgress
             miMinSolo = new MilestoneItem(Resources.MilestoneProgress.MinSolo, ResolvedFAR(String.Empty), String.Empty, MilestoneItem.MilestoneType.Time, 10.0M);
 
             // 61.109(ab)(1) - Dual XC
-            miMinDualXC = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinDualXC, szAircraftRestriction), ResolvedFAR("(1)"), String.Empty, MilestoneItem.MilestoneType.Time, 3.0M);
+            miMinDualXC = new MilestoneItemXC(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinDualXC, szAircraftRestriction), ResolvedFAR("(1)"), String.Empty, MilestoneItem.MilestoneType.Time, 3.0M);
 
             // 61.109(ab)(2) - Night
             miMinNightTime = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinNightTime, szAircraftRestriction), ResolvedFAR("(2)"), String.Empty, MilestoneItem.MilestoneType.Time, 3.0M);
-            miMinXCNight = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinXCNight, szAircraftRestriction, MinNightXCDistance), ResolvedFAR("(2)(i)"), String.Empty, MilestoneItem.MilestoneType.AchieveOnce, 1);
+            miMinXCNight = new MilestoneItemXC(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinXCNight, szAircraftRestriction, MinNightXCDistance), ResolvedFAR("(2)(i)"), String.Empty, MilestoneItem.MilestoneType.AchieveOnce, 1);
             miMinNightTO = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinNightTakeoffs, MinNightTakeoffs, szAircraftRestriction), ResolvedFAR("(2)(ii)"), Resources.MilestoneProgress.NoteNightRequirements, MilestoneItem.MilestoneType.Count, MinNightTakeoffs);
             miMinNightFSLandings = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinNightFSLandings, MinNightLandings, szAircraftRestriction), ResolvedFAR("(2)(ii)"), Resources.MilestoneProgress.NoteNightRequirements, MilestoneItem.MilestoneType.Count, MinNightLandings);
 
@@ -254,7 +254,7 @@ namespace MyFlightbook.RatingsProgress
 
             // 61.109(ab)(5) - XC requirements
             miMinSoloInType = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinSoloInType, szXCAircraftRestriction), ResolvedFAR("(5)"), Resources.MilestoneProgress.NoteSoloTime, MilestoneItem.MilestoneType.Time, 10.0M);
-            miMinXCSolo = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinXCSolo, szXCAircraftRestriction, MinXCSoloTime), ResolvedFAR("(5)(i)"), Resources.MilestoneProgress.NoteSoloTime, MilestoneItem.MilestoneType.Time, MinXCSoloTime);
+            miMinXCSolo = new MilestoneItemXC(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinXCSolo, szXCAircraftRestriction, MinXCSoloTime), ResolvedFAR("(5)(i)"), Resources.MilestoneProgress.NoteSoloTime, MilestoneItem.MilestoneType.Time, MinXCSoloTime);
             miMinXCDistance = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinXCDistance, szXCAircraftRestriction, MinXCSoloDistance, MinXCSoloSegment), ResolvedFAR("(5)(ii)"), Resources.MilestoneProgress.NoteXCLandings, MilestoneItem.MilestoneType.AchieveOnce, 1);
             miMinSoloTakeoffsTowered = new MilestoneItem(Resources.MilestoneProgress.MinTakeoffsToweredAirport, ResolvedFAR("(5)(iii)"), string.Empty, MilestoneItem.MilestoneType.Count, MinSoloTakeoffsTowered);
             miMinSoloLandingsTowered = new MilestoneItem(Resources.MilestoneProgress.MinLandingsFSToweredAirport, ResolvedFAR("(5)(iii)"), Resources.MilestoneProgress.NoteToweredAirport, MilestoneItem.MilestoneType.Count, MinSoloLandingsTowered);
@@ -304,6 +304,12 @@ namespace MyFlightbook.RatingsProgress
 
             // Only count flights over min 61.1 distance for the rating.
             decimal xc = cfr.XC > 0 && al.MaxDistanceFromStartingAirport() > MinXCDistanceForRating() ? cfr.XC : 0;
+            if (xc < cfr.XC)
+            {
+                miMinXCNight.AddIgnoredFlight(cfr);
+                miMinXCSolo.AddIgnoredFlight(cfr);
+                miMinDualXC.AddIgnoredFlight(cfr);
+            }
 
             if (fIsCorrectCatClass)
             {
@@ -412,11 +418,11 @@ namespace MyFlightbook.RatingsProgress
             miMinSolo = new MilestoneItem(Resources.MilestoneProgress.MinSolo, ResolvedFAR(""), String.Empty, MilestoneItem.MilestoneType.Time, 10.0M);
 
             // 61.109(c)(1) - Dual XC
-            miMinDualXC = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinDualXC, szHelicopterRestriction), ResolvedFAR("(1)"), String.Empty, MilestoneItem.MilestoneType.Time, 3.0M);
+            miMinDualXC = new MilestoneItemXC(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinDualXC, szHelicopterRestriction), ResolvedFAR("(1)"), String.Empty, MilestoneItem.MilestoneType.Time, 3.0M);
 
             // 61.109(c)(2) - Night
             miMinNightTime = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinNightTime, szHelicopterRestriction), ResolvedFAR("(2)"), String.Empty, MilestoneItem.MilestoneType.Time, 3.0M);
-            miMinXCNight = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinXCNight, szHelicopterRestriction, MinNightXCDistance), ResolvedFAR("(2)(i)"), String.Empty, MilestoneItem.MilestoneType.AchieveOnce, 1);
+            miMinXCNight = new MilestoneItemXC(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinXCNight, szHelicopterRestriction, MinNightXCDistance), ResolvedFAR("(2)(i)"), String.Empty, MilestoneItem.MilestoneType.AchieveOnce, 1);
             miMinNightTO = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinNightTakeoffs, MinNightTakeoffs, szHelicopterRestriction), ResolvedFAR("(2)(ii)"), Resources.MilestoneProgress.NoteNightRequirements, MilestoneItem.MilestoneType.Count, MinNightLandings);
             miMinNightFSLandings = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinNightFSLandings, MinNightLandings, szHelicopterRestriction), ResolvedFAR("(2)(ii)"), Resources.MilestoneProgress.NoteNightRequirements, MilestoneItem.MilestoneType.Count, MinNightTakeoffs);
 
@@ -425,7 +431,7 @@ namespace MyFlightbook.RatingsProgress
 
             // 61.109(c)(4) - Solo and XC requirements
             miMinSoloInType = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinSoloInType, szHelicopterRestriction), ResolvedFAR("(4)"), Resources.MilestoneProgress.NoteSoloTime, MilestoneItem.MilestoneType.Time, 10.0M);
-            miMinXCSolo = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinXCSolo, szHelicopterRestriction, MinXCSoloTime), ResolvedFAR("(4)(i)"), Resources.MilestoneProgress.NoteSoloTime, MilestoneItem.MilestoneType.Time, MinXCSoloTime);
+            miMinXCSolo = new MilestoneItemXC(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinXCSolo, szHelicopterRestriction, MinXCSoloTime), ResolvedFAR("(4)(i)"), Resources.MilestoneProgress.NoteSoloTime, MilestoneItem.MilestoneType.Time, MinXCSoloTime);
             miMinXCDistance = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.MinXCDistance, szHelicopterRestriction, MinXCSoloDistance, MinXCSoloSegment), ResolvedFAR("(4)(ii), 61.109(a)(4)(iii)"), Resources.MilestoneProgress.NoteXCLandings, MilestoneItem.MilestoneType.AchieveOnce, 1);
 
             miMinSoloTakeoffsTowered = new MilestoneItem(Resources.MilestoneProgress.MinTakeoffsToweredAirport, ResolvedFAR("(4)(iii)"), string.Empty, MilestoneItem.MilestoneType.Count, MinSoloTakeoffsTowered);

--- a/MyFlightbook.Web/AppCode/Flights/Ratings/SportRatings.cs
+++ b/MyFlightbook.Web/AppCode/Flights/Ratings/SportRatings.cs
@@ -71,7 +71,7 @@ namespace MyFlightbook.RatingsProgress
     public abstract class SportPilotAirplaneGyroplane : SportPilotBase
     {
         protected int MinXCDistance { get; set; }
-        protected MilestoneItem miMinCrossCountry { get; set; }
+        protected MilestoneItemXC miMinCrossCountry { get; set; }
         protected MilestoneItem miMinLandings { get; set; }
         protected MilestoneItem miSoloXCFlight { get; set; }
 
@@ -82,7 +82,7 @@ namespace MyFlightbook.RatingsProgress
             miMinInstruction = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.SportMinInstruction, minInstruction, CategoryName), szFar, string.Empty, MilestoneItem.MilestoneType.Time, minInstruction);
             miMinSolo = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.SportMinSolo, minSolo, CategoryName), szFar, string.Empty, MilestoneItem.MilestoneType.Time, minSolo);
 
-            miMinCrossCountry = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.SportMinXC, CategoryName), ResolvedFAR("(1)(i)"), string.Empty, MilestoneItem.MilestoneType.Time, 2.0M);
+            miMinCrossCountry = new MilestoneItemXC(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.SportMinXC, CategoryName), ResolvedFAR("(1)(i)"), string.Empty, MilestoneItem.MilestoneType.Time, 2.0M);
             miMinLandings = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.SportMinLandings, CategoryName), ResolvedFAR("(1)(ii)"), Resources.MilestoneProgress.SportPilotLandingNote, MilestoneItem.MilestoneType.Count, 10);
             miSoloXCFlight = new MilestoneItem(String.Format(CultureInfo.CurrentCulture, Resources.MilestoneProgress.SportSoloXCFlight, CategoryName, MinXCDistance), ResolvedFAR("(1)(iii)"), string.Empty, MilestoneItem.MilestoneType.AchieveOnce, 1);
             miTestPrep = new MilestoneItemDecayable(Resources.MilestoneProgress.SportTestPrepTime, ResolvedFAR("(1)(iv)"), Branding.ReBrand(Resources.MilestoneProgress.NoteTestPrep), MilestoneItem.MilestoneType.Time, 2.0M, 2);
@@ -114,6 +114,10 @@ namespace MyFlightbook.RatingsProgress
 
             int cFSLandings = cfr.cFullStopLandings + cfr.cFullStopNightLandings;
             miMinCrossCountry.AddEvent(Math.Min(xc, cfr.Dual));
+
+            if (cfr.XC > xc && cfr.Dual > 0)
+                miMinCrossCountry.AddIgnoredFlight(cfr);
+
             miMinLandings.AddEvent(cFSLandings);
             if (soloTime > 0 && cFSLandings > 1)
             {

--- a/MyFlightbook.Web/App_GlobalResources/MilestoneProgress.designer.cs
+++ b/MyFlightbook.Web/App_GlobalResources/MilestoneProgress.designer.cs
@@ -1879,6 +1879,15 @@ namespace Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The following flights were not included because the cross-country distance did not meet the requirements of 61.1 for this rating:.
+        /// </summary>
+        internal static string DetailFlightsIgnored {
+            get {
+                return ResourceManager.GetString("DetailFlightsIgnored", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to *{0:#,##0}* hours *CFI* time in *{1}*.
         /// </summary>
         internal static string DPECFICategory {

--- a/MyFlightbook.Web/App_GlobalResources/MilestoneProgress.resx
+++ b/MyFlightbook.Web/App_GlobalResources/MilestoneProgress.resx
@@ -1678,4 +1678,7 @@ YOU ARE ULTIMATELY RESPONSIBLE FOR ENSURING THAT YOU HAVE THE REQUIRED AERONAUTI
   <data name="CustomProgressNewMilestoneValue" xml:space="preserve">
     <value>Sum of: </value>
   </data>
+  <data name="DetailFlightsIgnored" xml:space="preserve">
+    <value>The following flights were not included because the cross-country distance did not meet the requirements of 61.1 for this rating:</value>
+  </data>
 </root>

--- a/MyFlightbook.Web/Member/RatingProgress.aspx
+++ b/MyFlightbook.Web/Member/RatingProgress.aspx
@@ -178,11 +178,17 @@
             </asp:TemplateField>
             <asp:TemplateField>
                 <ItemTemplate>
-                    <div><span style="font-weight:bold"><%# ((string) Eval("FARRef")).Linkify(false) %></span> - <%# ((string) Eval("Title")).Linkify(true) %> <asp:Label ID="lblExpiration" runat="server" Font-Bold="true" Text='<%#: Eval("ExpirationNote") %>' /></div>
+                    <div>
+                        <span style="font-weight:bold"><%# ((string) Eval("FARRef")).Linkify(false) %></span> - <%# ((string) Eval("Title")).Linkify(true) %> <asp:Label ID="lblExpiration" runat="server" Font-Bold="true" Text='<%#: Eval("ExpirationNote") %>' />
+                        <asp:Image ID="imgDetails" runat="server" Visible='<%# Eval("HasDetails") %>' ImageUrl="~/images/expand.png" />
+                    </div>
                     <asp:Panel ID="pnlNote" CssClass="fineprint" runat="server">
                         <asp:Label ID="lblNoteHeader" runat="server" Font-Bold="true" Text="<%$ Resources:MilestoneProgress, NoteHeader %>" />
                         <span style="font-style:italic"><%# ((string) Eval("Note")).Linkify(true) %></span>
                     </asp:Panel>
+                    <ajaxtoolkit:CollapsiblePanelExtender ID="cpeDisplayMode" runat="server" Collapsed='true' Enabled='<%# Eval("HasDetails") %>'
+                        TargetControlID="pnlDetails" CollapsedImage="~/images/expand.png" ExpandedImage="~/images/collapse.png" CollapseControlID="imgDetails" ExpandControlID="imgDetails" ImageControlID="imgDetails" />
+                    <asp:Panel ID="pnlDetails" runat="server"><span style="white-space:pre-line""><%# ((string) Eval("Details")).Linkify() %></span></asp:Panel>
                     <asp:MultiView ID="mvProgress" runat="server">
                         <asp:View ID="vwPercentage" runat="server">
                             <div class="progress">


### PR DESCRIPTION
…o insufficient distance

 - New virtual Details and HasDetails properties on MilestoneItem.  If present, indicates details
 - New MilestoneItemXC that allows you to indicate ignored flights.  This fills in the details for these flights.
 - Sport, Comm, PPL, and INstrument ratings now use MilestoneItemXC and fill in ignored flights.
 - RatingsProgress.aspx now shows an expando with the ratings (linkified) if HasDetails is true.