### PR TITLE
Avoid repeated enumeration in KML parsing

### DIFF
--- a/MyFlightbook.Telemetry.Tests/KMLParserTests.cs
+++ b/MyFlightbook.Telemetry.Tests/KMLParserTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MyFlightbook.Charting;
+using MyFlightbook.Telemetry;
+
+namespace MyFlightbook.Telemetry.Tests
+{
+    [TestClass]
+    public class KMLParserTests
+    {
+        [TestMethod]
+        public void Parse_LineStringCoordinatesAcrossMultiplePlacemarks_ParsesAllSamples()
+        {
+            const string kml = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <kml xmlns="http://www.opengis.net/kml/2.2">
+                  <Placemark>
+                    <LineString>
+                      <coordinates>-122.1000,47.1000,100 -122.2000,47.2000,200</coordinates>
+                    </LineString>
+                  </Placemark>
+                  <Placemark>
+                    <LineString>
+                      <coordinates>-122.3000,47.3000,300</coordinates>
+                    </LineString>
+                  </Placemark>
+                </kml>
+                """;
+
+            KMLParser parser = new KMLParser
+            {
+                ParsedData = new TelemetryDataTable()
+            };
+
+            bool parsed = parser.Parse(kml);
+
+            Assert.IsTrue(parsed, parser.ErrorString);
+            Assert.AreEqual(3, parser.ParsedData.Rows.Count);
+            Assert.AreEqual(47.1, Convert.ToDouble(parser.ParsedData.Rows[0][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(-122.3, Convert.ToDouble(parser.ParsedData.Rows[2][KnownColumnNames.LON], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(300, Convert.ToInt32(parser.ParsedData.Rows[2][KnownColumnNames.ALT], CultureInfo.InvariantCulture));
+        }
+
+        [TestMethod]
+        public void Parse_GxTrack_ParsesCoordinatesAndTimestampsWithoutRepeatedEnumeration()
+        {
+            const string kml = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:09:26Z</when>
+                      <when>2025-03-14T19:10:26Z</when>
+                      <gx:coord>-122.3493 47.6205 376.2756</gx:coord>
+                      <gx:coord>-122.3501 47.6210 400</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                </kml>
+                """;
+
+            KMLParser parser = new KMLParser
+            {
+                ParsedData = new TelemetryDataTable()
+            };
+
+            bool parsed = parser.Parse(kml);
+
+            Assert.IsTrue(parsed, parser.ErrorString);
+            Assert.AreEqual(2, parser.ParsedData.Rows.Count);
+            Assert.AreEqual(DateTime.Parse("2025-03-14T19:09:26Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal),
+                (DateTime)parser.ParsedData.Rows[0][KnownColumnNames.TIME]);
+            Assert.AreEqual(DateTime.Parse("2025-03-14T19:10:26Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal),
+                (DateTime)parser.ParsedData.Rows[1][KnownColumnNames.TIME]);
+            Assert.AreEqual(47.621, Convert.ToDouble(parser.ParsedData.Rows[1][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(-122.3501, Convert.ToDouble(parser.ParsedData.Rows[1][KnownColumnNames.LON], CultureInfo.InvariantCulture), 0.0001);
+        }
+    }
+}

--- a/MyFlightbook.Telemetry.Tests/MyFlightbook.Telemetry.Tests.csproj
+++ b/MyFlightbook.Telemetry.Tests/MyFlightbook.Telemetry.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyFlightbook.Telemetry\MyFlightbook.Telemetry.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MyFlightbook.Telemetry/KML.cs
+++ b/MyFlightbook.Telemetry/KML.cs
@@ -254,8 +254,8 @@ namespace MyFlightbook.Telemetry
             else if (k.eleCoords != null)
             {
                 StringBuilder sb = new StringBuilder();
-                for (int i = 0; i < k.eleCoords.Count(); i++)
-                    sb.AppendFormat(CultureInfo.InvariantCulture, "{0} ", (k.eleCoords.ElementAt(i).Value.Replace("\r", " ").Replace("\n", " ")));
+                foreach (XElement coordElement in k.eleCoords)
+                    sb.AppendFormat(CultureInfo.InvariantCulture, "{0} ", coordElement.Value.Replace("\r", " ").Replace("\n", " "));
                 coords = sb.ToString();
             }
             else
@@ -295,26 +295,24 @@ namespace MyFlightbook.Telemetry
 
         private bool ParseKMLv2(KMLElements k)
         {
-            var timeStamps = k.ele22.Descendants(k.ns + "when");
-            var coords = k.ele22.Descendants(k.ns22 + "coord");
-
-            int cCoords = coords.Count();
-
             List<Position> lstSamples = new List<Position>();
-            for (int iRow = 0; iRow < cCoords; iRow++)
+            using (IEnumerator<XElement> timestampEnumerator = k.ele22.Descendants(k.ns + "when").GetEnumerator())
             {
-                var coord = coords.ElementAt(iRow);
-                string[] rgRow = coord.Value.Split(new char[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
-                Position sample = new Position(rgRow);
-
-                if (iRow < timeStamps.Count())
+                foreach (XElement coord in k.ele22.Descendants(k.ns22 + "coord"))
                 {
-                    sample.TypeOfSpeed = Position.SpeedType.Derived;
-                    string szTimeStamp = timeStamps.ElementAt(iRow).Value;
-                    if (!String.IsNullOrEmpty(szTimeStamp))
-                        sample.Timestamp = szTimeStamp.ParseUTCDate();
+                    string[] rgRow = coord.Value.Split(new char[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    Position sample = new Position(rgRow);
+
+                    if (timestampEnumerator.MoveNext())
+                    {
+                        sample.TypeOfSpeed = Position.SpeedType.Derived;
+                        string szTimeStamp = timestampEnumerator.Current.Value;
+                        if (!String.IsNullOrEmpty(szTimeStamp))
+                            sample.Timestamp = szTimeStamp.ParseUTCDate();
+                    }
+
+                    lstSamples.Add(sample);
                 }
-                lstSamples.Add(sample);
             }
 
             // Derive speed or see if it is available in extended data.

--- a/MyFlightbook.sln
+++ b/MyFlightbook.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyFlightbook.Image", "MyFli
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyFlightbook.AircraftSupport", "MyFlightbook.AircraftSupport\MyFlightbook.AircraftSupport.csproj", "{5C8915D0-92CA-1B06-BAE8-00AE1914A47F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyFlightbook.Telemetry.Tests", "MyFlightbook.Telemetry.Tests\MyFlightbook.Telemetry.Tests.csproj", "{B9018F2D-C59B-481B-925A-D12C9A908D0A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,10 @@ Global
 		{5C8915D0-92CA-1B06-BAE8-00AE1914A47F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5C8915D0-92CA-1B06-BAE8-00AE1914A47F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5C8915D0-92CA-1B06-BAE8-00AE1914A47F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9018F2D-C59B-481B-925A-D12C9A908D0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9018F2D-C59B-481B-925A-D12C9A908D0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9018F2D-C59B-481B-925A-D12C9A908D0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9018F2D-C59B-481B-925A-D12C9A908D0A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Hey Eric,

I noticed the KML parser was repeatedly enumerating deferred XML sequences in both parser paths.

In the `LineString` path, `eleCoords` was being walked with `Count()` and `ElementAt(i)` in a loop. In the `gx:Track` path, `coords` and `timeStamps` had the same basic issue. Since these are LINQ-to-XML enumerables, that turns into repeated tree walks and gives the parser quadratic behavior as the number of points grows.

This changes both paths to iterate linearly:
- `LineString` now uses a single `foreach`
- `gx:Track` now walks coordinates once and advances a timestamp enumerator alongside them, so it avoids both repeated enumeration and the extra list allocation from materializing the sequences first

I also added a small telemetry test project with coverage for:
- multiple `<coordinates>` elements across placemarks
- `gx:Track` parsing with timestamp/value assertions

I ran the telemetry tests in Podman and they passed.
