### PR TITLE
Initial cut at IUserProfile, used by CustomPropertyTypes

### DIFF
--- a/MyFlightbook.SharedUtility/util.cs
+++ b/MyFlightbook.SharedUtility/util.cs
@@ -59,6 +59,8 @@ namespace MyFlightbook
         string RelativeToAbsolute(string relativePath);
 
         string RelativeToAbsoluteFilePath(string relativePath);
+
+        IUserProfile GetUser(string szUser);
     }
 
     /// <summary>
@@ -93,6 +95,48 @@ namespace MyFlightbook
         int FlushCache();
 
         IEnumerator GetEnumerator();
+    }
+
+    /// <summary>
+    /// Defines a basic user profile with common attributes and functionality - mostly name, username, email, and caching
+    /// </summary>
+    public interface IUserProfile
+    {
+        /// <summary>
+        /// The internal invariant username for the user
+        /// </summary>
+        string UserName { get; }
+        /// <summary>
+        /// Given name to use for this user
+        /// </summary>
+        string UserFirstName { get; }
+        /// <summary>
+        /// Surname to use for this user
+        /// </summary>
+        string UserLastName { get; }
+        /// <summary>
+        /// Full name to use for this user
+        /// </summary>
+        string UserFullName { get; }
+        /// <summary>
+        /// User's email address
+        /// </summary>
+        string Email { get; }
+        /// <summary>
+        /// Convenience dictionary of cached data associated with the user
+        /// TREAT THIS AS A PER-USER CACHE - it can be flushed
+        /// </summary>
+        IDictionary<string, object> AssociatedData { get; }
+        /// <summary>
+        /// Safe way to get a cached object from AssociatedData (i.e., can return null)
+        /// </summary>
+        /// <param name="szKey">Key for the object</param>
+        /// <returns></returns>
+        object CachedObject(string szKey);
+        /// <summary>
+        /// Set of property IDs that the user has blocked.
+        /// </summary>
+        HashSet<int> BlocklistedProperties { get; }
     }
 
     /// <summary>

--- a/MyFlightbook.Web/AppCode/Flights/Properties.cs
+++ b/MyFlightbook.Web/AppCode/Flights/Properties.cs
@@ -749,7 +749,7 @@ WHERE idPropType = {0} ORDER BY Title ASC", id));
 
         public static void FlushUserCache(string szUser)
         {
-            Profile pf = Profile.GetUser(szUser);
+            IUserProfile pf = util.RequestContext.GetUser(szUser);
             pf.AssociatedData.Remove(szAppCacheKey);
         }
 
@@ -887,7 +887,7 @@ ORDER BY IsFavorite DESC, IF(SortKey='', Title, SortKey) ASC";
                 if (!fForceLoad)
                 {
                     // Try to return props from the user profile.
-                    CustomPropertyType[] rgProps = (CustomPropertyType[])Profile.GetUser(szUser).CachedObject(szAppCacheKey);
+                    CustomPropertyType[] rgProps = (CustomPropertyType[])util.RequestContext.GetUser(szUser).CachedObject(szAppCacheKey);
                     if (rgProps != null)
                         return rgProps;
                 }
@@ -906,7 +906,7 @@ FROM custompropertytypes cpt
 ORDER BY IF(SortKey='', Title, SortKey) ASC";
             else
             {
-                Profile pf = Profile.GetUser(szUser);
+                IUserProfile pf = util.RequestContext.GetUser(szUser);
                 szQ = String.Format(CultureInfo.InvariantCulture, szCustomPropsForUserQuery, pf.BlocklistedProperties.Count == 0 ? string.Empty : String.Format(CultureInfo.InvariantCulture, " AND fp.idPropType NOT IN ('{0}') ", String.Join("', '", pf.BlocklistedProperties)));
             }
 
@@ -926,7 +926,7 @@ ORDER BY IF(SortKey='', Title, SortKey) ASC";
             if (String.IsNullOrEmpty(szUser))
                 util.GlobalCache.Set(szAppCacheKey, rgcpt, DateTimeOffset.UtcNow.AddHours(2));
             else
-                Profile.GetUser(szUser).AssociatedData[szAppCacheKey] = rgcpt;
+                util.RequestContext.GetUser(szUser).AssociatedData[szAppCacheKey] = rgcpt;
 
             return rgcpt;
         }

--- a/MyFlightbook.Web/AppCode/Flights/Totals.cs
+++ b/MyFlightbook.Web/AppCode/Flights/Totals.cs
@@ -846,7 +846,7 @@ namespace MyFlightbook.Currency
                         CustomPropertyType cpt = new CustomPropertyType(dr);
 
                         // don't include blocklisted properties in totals.
-                        if (pf.BlocklistedProperties.Exists(i => i == cpt.PropTypeID))
+                        if (pf.BlocklistedProperties.Contains(cpt.PropTypeID))
                             continue;
 
                         bool fPropIsInQuery = Restriction.PropertyTypes.Contains(cpt);

--- a/MyFlightbook.Web/AppCode/UserAccounts/Profile.cs
+++ b/MyFlightbook.Web/AppCode/UserAccounts/Profile.cs
@@ -44,7 +44,7 @@ namespace MyFlightbook
     /// Encapsulates a user of the system.  This is the base class.
     /// </summary>
     [Serializable]
-    public abstract class ProfileBase
+    public abstract class ProfileBase : IUserProfile
     {
         #region creation/initialization
         protected ProfileBase()
@@ -97,6 +97,69 @@ namespace MyFlightbook
         /// Can this user see reports?
         /// </summary>
         public bool CanReport { get { return ProfileRoles.CanReport(Role); } }
+        #endregion
+
+        #region IUserProfile
+        /// <summary>
+        /// Username for the user
+        /// </summary>
+        public string UserName { get; set; }
+
+        /// <summary>
+        /// Gets just the first name for the logged in user, logged in user name if none
+        /// </summary>
+        /// <param name="szUser">Logged in user name</param>
+        /// <returns>First name</returns>
+        public string UserFirstName
+        {
+            get { return GetUserName(true, false); }
+        }
+
+        /// <summary>
+        /// Gets just the last name for the logged in user, logged in user name if none
+        /// </summary>
+        /// <param name="szUser">Logged in user name</param>
+        /// <returns>Last name</returns>
+        public string UserLastName
+        {
+            get { return GetUserName(false, true); }
+        }
+
+        /// <summary>
+        /// Gets the full name for the logged in user, logged in user name if none.
+        /// </summary>
+        /// <param name="szUser">Logged in user name</param>
+        /// <returns>Full name</returns>
+        public string UserFullName
+        {
+            get { return GetUserName(true, true); }
+        }
+
+        /// <summary>
+        /// User's email address
+        /// </summary>
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Convenience dictionary of associated data for other that want to piggy back on Profile caching.
+        /// </summary>
+        public IDictionary<string, object> AssociatedData { get; private set; } = new ConcurrentDictionary<string, object>();
+
+        /// <summary>
+        /// Safe way to get a cached object (i.e., can return null)
+        /// </summary>
+        /// <param name="szKey"></param>
+        /// <returns></returns>
+        public object CachedObject(string szKey)
+        {
+            return (AssociatedData.TryGetValue(szKey, out object o)) ? o : null;
+        }
+
+        /// <summary>
+        /// List of properties ID's that the user has blocklisted from the previously-used list.
+        /// </summary>
+        public HashSet<int> BlocklistedProperties { get; private set; } = new HashSet<int>();
+
         #endregion
 
         #region Properties
@@ -386,11 +449,6 @@ namespace MyFlightbook
         public DateTime LastPasswordChange { get; set; }
         #endregion
 
-            /// <summary>
-            /// Username for the user
-            /// </summary>
-        public string UserName { get; set; }
-
         /// <summary>
         /// Detailed name - username, display name, and email
         /// </summary>
@@ -482,11 +540,6 @@ namespace MyFlightbook
         public IAuthorizationState CloudAhoyToken { get; set; }
 
         /// <summary>
-        /// User's email address
-        /// </summary>
-        public string Email { get; set; }
-
-        /// <summary>
         /// The original email address for the user, so that we can tell if it has changed.
         /// </summary>
         protected string OriginalEmail { get; set; }
@@ -522,36 +575,6 @@ namespace MyFlightbook
         public DateTime EnglishProficiencyExpiration { get; set; }
 
         /// <summary>
-        /// Gets just the first name for the logged in user, logged in user name if none
-        /// </summary>
-        /// <param name="szUser">Logged in user name</param>
-        /// <returns>First name</returns>
-        public string UserFirstName
-        {
-            get { return GetUserName(true, false); }
-        }
-
-        /// <summary>
-        /// Gets just the last name for the logged in user, logged in user name if none
-        /// </summary>
-        /// <param name="szUser">Logged in user name</param>
-        /// <returns>Last name</returns>
-        public string UserLastName
-        {
-            get { return GetUserName(false, true); }
-        }
-
-        /// <summary>
-        /// Gets the full name for the logged in user, logged in user name if none.
-        /// </summary>
-        /// <param name="szUser">Logged in user name</param>
-        /// <returns>Full name</returns>
-        public string UserFullName
-        {
-            get { return GetUserName(true, true); }
-        }
-
-        /// <summary>
         /// The license number for the user
         /// </summary>
         public string License { get; set; }
@@ -560,11 +583,6 @@ namespace MyFlightbook
         /// The address for the user
         /// </summary>
         public string Address { get; set; }
-
-        /// <summary>
-        /// List of properties ID's that the user has blocklisted from the previously-used list.
-        /// </summary>
-        public List<int> BlocklistedProperties { get; private set; } = new List<int>();
 
         /// <summary>
         /// Current status of achievement computation for the user.  
@@ -592,11 +610,6 @@ namespace MyFlightbook
                 }
             }
         }
-
-        /// <summary>
-        /// Convenience dictionary of associated data for other that want to piggy back on Profile caching.
-        /// </summary>
-        public IDictionary<string, object> AssociatedData { get; private set; } = new ConcurrentDictionary<string, object>();
         #endregion
 
         /// <summary>
@@ -628,18 +641,6 @@ namespace MyFlightbook
                 return szEmail;
             }
         }
-
-        #region Associated data helpers
-        /// <summary>
-        /// Safe way to get a cached object (i.e., can return null)
-        /// </summary>
-        /// <param name="szKey"></param>
-        /// <returns></returns>
-        public object CachedObject(string szKey)
-        {
-            return (AssociatedData.TryGetValue(szKey, out object o)) ? o : null;
-        }
-        #endregion
     }
 
     /// <summary>
@@ -1052,8 +1053,9 @@ namespace MyFlightbook
 
                 PreferredTimeZoneID = (string) util.ReadNullableField(dr, "timezone", null);
 
-                string szBlockList = util.ReadNullableString(dr, "PropertyBlackList");
-                BlocklistedProperties.AddRange(szBlockList.ToInts());
+                IEnumerable<int> rgBlockedPropIds = util.ReadNullableString(dr, "PropertyBlackList").ToInts();
+                foreach (int idProp in rgBlockedPropIds)
+                    BlocklistedProperties.Add(idProp);
 
                 HeadShot = (byte[])util.ReadNullableField(dr, "HeadShot", null);
 

--- a/MyFlightbook.Web/AppCode/Utility/MVCRequestContext.cs
+++ b/MyFlightbook.Web/AppCode/Utility/MVCRequestContext.cs
@@ -87,5 +87,10 @@ namespace MyFlightbook.Injection
         {
             get { return (HttpContext.Current.Session?.Keys.Cast<string>()) ?? Array.Empty<string>(); }
         }
+
+        public IUserProfile GetUser(string szUser)
+        {
+            return Profile.GetUser(szUser);
+        }
     }
 }

--- a/MyFlightbook.Web/Areas/mvc/Controllers/PrefsController.cs
+++ b/MyFlightbook.Web/Areas/mvc/Controllers/PrefsController.cs
@@ -241,7 +241,7 @@ namespace MyFlightbook.Web.Areas.mvc.Controllers
                 {
                     if (pf.BlocklistedProperties.Contains(id))
                     {
-                        pf.BlocklistedProperties.RemoveAll(idPropType => id == idPropType);
+                        pf.BlocklistedProperties.Remove(id);
                         pf.FCommit();
                         // refresh the cache
                         CustomPropertyType.GetCustomPropertyTypes(User.Identity.Name, true);


### PR DESCRIPTION
 * IUserProfile contains truly core functions of the profile
 * IRequestContext (and thus MVCRequestContext) implements GetUser which returns an IUserProfile
 * Custompropertytypes is the first guinea pig, onliy using iUserProfile instead of the full Profile object.
 * Changed PropertyBlockList to a hashset rather than a List - should be more efficient, better capture the semantics.