### PR TITLE
Parse all gx:Track placemarks in KML telemetry, not just the first

### DIFF
--- a/MyFlightbook.Telemetry.Tests/KMLParserTests.cs
+++ b/MyFlightbook.Telemetry.Tests/KMLParserTests.cs
@@ -93,7 +93,9 @@ namespace MyFlightbook.Telemetry.Tests
                   <Placemark>
                     <gx:Track>
                       <when>2025-03-14T19:11:26Z</when>
+                      <when>2025-03-14T19:11:42Z</when>
                       <gx:coord>-122.3510 47.6215 420</gx:coord>
+                      <gx:coord>-122.3520 47.6220 430</gx:coord>
                     </gx:Track>
                   </Placemark>
                 </kml>
@@ -107,11 +109,350 @@ namespace MyFlightbook.Telemetry.Tests
             bool parsed = parser.Parse(kml);
 
             Assert.IsTrue(parsed, parser.ErrorString);
-            Assert.AreEqual(3, parser.ParsedData.Rows.Count);
-            Assert.AreEqual(DateTime.Parse("2025-03-14T19:11:26Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal),
-                (DateTime)parser.ParsedData.Rows[2][KnownColumnNames.TIME]);
-            Assert.AreEqual(47.6215, Convert.ToDouble(parser.ParsedData.Rows[2][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
-            Assert.AreEqual(-122.3510, Convert.ToDouble(parser.ParsedData.Rows[2][KnownColumnNames.LON], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(4, parser.ParsedData.Rows.Count);
+            Assert.AreEqual(DateTime.Parse("2025-03-14T19:11:42Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal),
+                (DateTime)parser.ParsedData.Rows[3][KnownColumnNames.TIME]);
+            Assert.AreEqual(47.6220, Convert.ToDouble(parser.ParsedData.Rows[3][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(-122.3520, Convert.ToDouble(parser.ParsedData.Rows[3][KnownColumnNames.LON], CultureInfo.InvariantCulture), 0.0001);
+        }
+
+        [TestMethod]
+        public void Parse_GxTracksOutOfChronologicalOrder_SortsByStartTime()
+        {
+            const string kml = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:20:00Z</when>
+                      <when>2025-03-14T19:20:16Z</when>
+                      <gx:coord>-122.1000 47.1000 100</gx:coord>
+                      <gx:coord>-122.1100 47.1100 110</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:00:00Z</when>
+                      <when>2025-03-14T19:00:16Z</when>
+                      <gx:coord>-122.3000 47.3000 300</gx:coord>
+                      <gx:coord>-122.3100 47.3100 310</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                </kml>
+                """;
+
+            KMLParser parser = new KMLParser
+            {
+                ParsedData = new TelemetryDataTable()
+            };
+
+            bool parsed = parser.Parse(kml);
+
+            Assert.IsTrue(parsed, parser.ErrorString);
+            Assert.AreEqual(4, parser.ParsedData.Rows.Count);
+            Assert.AreEqual(DateTime.Parse("2025-03-14T19:00:00Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal),
+                (DateTime)parser.ParsedData.Rows[0][KnownColumnNames.TIME]);
+            Assert.AreEqual(47.3000, Convert.ToDouble(parser.ParsedData.Rows[0][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(DateTime.Parse("2025-03-14T19:20:16Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal),
+                (DateTime)parser.ParsedData.Rows[3][KnownColumnNames.TIME]);
+            Assert.AreEqual(47.1100, Convert.ToDouble(parser.ParsedData.Rows[3][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+            Assert.IsNotNull(parser.ParsedData.Columns[KnownColumnNames.DERIVEDSPEED]);
+        }
+
+        [TestMethod]
+        public void Parse_GxTrackTimestampedThenNaked_DropsNakedTrack()
+        {
+            const string kml = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:00:00Z</when>
+                      <when>2025-03-14T19:00:16Z</when>
+                      <gx:coord>-122.1000 47.1000 100</gx:coord>
+                      <gx:coord>-122.1100 47.1100 110</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                  <Placemark>
+                    <gx:Track>
+                      <gx:coord>-122.9000 47.9000 900</gx:coord>
+                      <gx:coord>-122.9100 47.9100 910</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                </kml>
+                """;
+
+            KMLParser parser = new KMLParser
+            {
+                ParsedData = new TelemetryDataTable()
+            };
+
+            bool parsed = parser.Parse(kml);
+
+            Assert.IsTrue(parsed, parser.ErrorString);
+            Assert.AreEqual(2, parser.ParsedData.Rows.Count);
+            Assert.IsNotNull(parser.ParsedData.Columns[KnownColumnNames.TIME]);
+            Assert.AreEqual(47.1000, Convert.ToDouble(parser.ParsedData.Rows[0][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(47.1100, Convert.ToDouble(parser.ParsedData.Rows[1][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+        }
+
+        [TestMethod]
+        public void Parse_GxTracksAllNaked_MergesInDocumentOrder()
+        {
+            const string kml = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+                  <Placemark>
+                    <gx:Track>
+                      <gx:coord>-122.1000 47.1000 100</gx:coord>
+                      <gx:coord>-122.1100 47.1100 110</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                  <Placemark>
+                    <gx:Track>
+                      <gx:coord>-122.2000 47.2000 200</gx:coord>
+                      <gx:coord>-122.2100 47.2100 210</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                </kml>
+                """;
+
+            KMLParser parser = new KMLParser
+            {
+                ParsedData = new TelemetryDataTable()
+            };
+
+            bool parsed = parser.Parse(kml);
+
+            Assert.IsTrue(parsed, parser.ErrorString);
+            Assert.AreEqual(4, parser.ParsedData.Rows.Count);
+            Assert.IsNull(parser.ParsedData.Columns[KnownColumnNames.TIME]);
+            Assert.AreEqual(47.1000, Convert.ToDouble(parser.ParsedData.Rows[0][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(47.2100, Convert.ToDouble(parser.ParsedData.Rows[3][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+        }
+
+        [TestMethod]
+        public void Parse_GxTrackSinglePointPlacemark_IsIgnored()
+        {
+            const string kml = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:00:00Z</when>
+                      <when>2025-03-14T19:00:16Z</when>
+                      <gx:coord>-122.1000 47.1000 100</gx:coord>
+                      <gx:coord>-122.1100 47.1100 110</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:05:00Z</when>
+                      <gx:coord>-122.5000 47.5000 500</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                </kml>
+                """;
+
+            KMLParser parser = new KMLParser
+            {
+                ParsedData = new TelemetryDataTable()
+            };
+
+            bool parsed = parser.Parse(kml);
+
+            Assert.IsTrue(parsed, parser.ErrorString);
+            Assert.AreEqual(2, parser.ParsedData.Rows.Count);
+            Assert.AreEqual(47.1000, Convert.ToDouble(parser.ParsedData.Rows[0][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(47.1100, Convert.ToDouble(parser.ParsedData.Rows[1][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+        }
+
+        [TestMethod]
+        public void Parse_GxTracksWithReportedSpeed_StayAlignedAfterSort()
+        {
+            const string kml = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:20:00Z</when>
+                      <when>2025-03-14T19:20:16Z</when>
+                      <gx:coord>-122.1000 47.1000 100</gx:coord>
+                      <gx:coord>-122.1100 47.1100 110</gx:coord>
+                      <ExtendedData>
+                        <SchemaData>
+                          <gx:SimpleArrayData name="speed_kts">
+                            <gx:value>100</gx:value>
+                            <gx:value>110</gx:value>
+                          </gx:SimpleArrayData>
+                        </SchemaData>
+                      </ExtendedData>
+                    </gx:Track>
+                  </Placemark>
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:00:00Z</when>
+                      <when>2025-03-14T19:00:16Z</when>
+                      <gx:coord>-122.3000 47.3000 300</gx:coord>
+                      <gx:coord>-122.3100 47.3100 310</gx:coord>
+                      <ExtendedData>
+                        <SchemaData>
+                          <gx:SimpleArrayData name="speed_kts">
+                            <gx:value>50</gx:value>
+                            <gx:value>60</gx:value>
+                          </gx:SimpleArrayData>
+                        </SchemaData>
+                      </ExtendedData>
+                    </gx:Track>
+                  </Placemark>
+                </kml>
+                """;
+
+            KMLParser parser = new KMLParser
+            {
+                ParsedData = new TelemetryDataTable()
+            };
+
+            bool parsed = parser.Parse(kml);
+
+            Assert.IsTrue(parsed, parser.ErrorString);
+            Assert.AreEqual(4, parser.ParsedData.Rows.Count);
+            Assert.IsNotNull(parser.ParsedData.Columns[KnownColumnNames.SPEED]);
+            Assert.AreEqual(50, Convert.ToDouble(parser.ParsedData.Rows[0][KnownColumnNames.SPEED], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(60, Convert.ToDouble(parser.ParsedData.Rows[1][KnownColumnNames.SPEED], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(100, Convert.ToDouble(parser.ParsedData.Rows[2][KnownColumnNames.SPEED], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(110, Convert.ToDouble(parser.ParsedData.Rows[3][KnownColumnNames.SPEED], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(DateTime.Parse("2025-03-14T19:00:00Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal),
+                (DateTime)parser.ParsedData.Rows[0][KnownColumnNames.TIME]);
+            Assert.AreEqual(DateTime.Parse("2025-03-14T19:20:16Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal),
+                (DateTime)parser.ParsedData.Rows[3][KnownColumnNames.TIME]);
+        }
+
+        [TestMethod]
+        public void Parse_GxMultiTrack_ParsesAllSegments()
+        {
+            const string kml = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+                  <Placemark>
+                    <gx:MultiTrack>
+                      <gx:Track>
+                        <when>2025-03-14T19:00:00Z</when>
+                        <when>2025-03-14T19:00:16Z</when>
+                        <gx:coord>-122.1000 47.1000 100</gx:coord>
+                        <gx:coord>-122.1100 47.1100 110</gx:coord>
+                      </gx:Track>
+                      <gx:Track>
+                        <when>2025-03-14T19:10:00Z</when>
+                        <when>2025-03-14T19:10:16Z</when>
+                        <gx:coord>-122.2000 47.2000 200</gx:coord>
+                        <gx:coord>-122.2100 47.2100 210</gx:coord>
+                      </gx:Track>
+                    </gx:MultiTrack>
+                  </Placemark>
+                </kml>
+                """;
+
+            KMLParser parser = new KMLParser
+            {
+                ParsedData = new TelemetryDataTable()
+            };
+
+            bool parsed = parser.Parse(kml);
+
+            Assert.IsTrue(parsed, parser.ErrorString);
+            Assert.AreEqual(4, parser.ParsedData.Rows.Count);
+            Assert.AreEqual(DateTime.Parse("2025-03-14T19:00:00Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal),
+                (DateTime)parser.ParsedData.Rows[0][KnownColumnNames.TIME]);
+            Assert.AreEqual(DateTime.Parse("2025-03-14T19:10:16Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal),
+                (DateTime)parser.ParsedData.Rows[3][KnownColumnNames.TIME]);
+        }
+
+        [TestMethod]
+        public void Parse_GxTracksMixedReportedSpeed_DropsSpeedlessTrack()
+        {
+            const string kml = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:00:00Z</when>
+                      <when>2025-03-14T19:00:16Z</when>
+                      <gx:coord>-122.1000 47.1000 100</gx:coord>
+                      <gx:coord>-122.1100 47.1100 110</gx:coord>
+                      <ExtendedData>
+                        <SchemaData>
+                          <gx:SimpleArrayData name="speed_kts">
+                            <gx:value>50</gx:value>
+                            <gx:value>60</gx:value>
+                          </gx:SimpleArrayData>
+                        </SchemaData>
+                      </ExtendedData>
+                    </gx:Track>
+                  </Placemark>
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:10:00Z</when>
+                      <when>2025-03-14T19:10:16Z</when>
+                      <gx:coord>-122.2000 47.2000 200</gx:coord>
+                      <gx:coord>-122.2100 47.2100 210</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                </kml>
+                """;
+
+            KMLParser parser = new KMLParser
+            {
+                ParsedData = new TelemetryDataTable()
+            };
+
+            bool parsed = parser.Parse(kml);
+
+            Assert.IsTrue(parsed, parser.ErrorString);
+            Assert.AreEqual(2, parser.ParsedData.Rows.Count);
+            Assert.IsNotNull(parser.ParsedData.Columns[KnownColumnNames.SPEED]);
+            Assert.AreEqual(47.1000, Convert.ToDouble(parser.ParsedData.Rows[0][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(50, Convert.ToDouble(parser.ParsedData.Rows[0][KnownColumnNames.SPEED], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(60, Convert.ToDouble(parser.ParsedData.Rows[1][KnownColumnNames.SPEED], CultureInfo.InvariantCulture), 0.0001);
+        }
+
+        [TestMethod]
+        public void Parse_GxTrackWithFewerTimestampsThanCoordinates_IsDropped()
+        {
+            const string kml = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:00:00Z</when>
+                      <when>2025-03-14T19:00:16Z</when>
+                      <gx:coord>-122.1000 47.1000 100</gx:coord>
+                      <gx:coord>-122.1100 47.1100 110</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:05:00Z</when>
+                      <when>2025-03-14T19:05:16Z</when>
+                      <gx:coord>-122.5000 47.5000 500</gx:coord>
+                      <gx:coord>-122.5100 47.5100 510</gx:coord>
+                      <gx:coord>-122.5200 47.5200 520</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                </kml>
+                """;
+
+            KMLParser parser = new KMLParser
+            {
+                ParsedData = new TelemetryDataTable()
+            };
+
+            bool parsed = parser.Parse(kml);
+
+            Assert.IsTrue(parsed, parser.ErrorString);
+            Assert.AreEqual(2, parser.ParsedData.Rows.Count);
+            Assert.AreEqual(47.1000, Convert.ToDouble(parser.ParsedData.Rows[0][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(47.1100, Convert.ToDouble(parser.ParsedData.Rows[1][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
         }
     }
 }

--- a/MyFlightbook.Telemetry.Tests/KMLParserTests.cs
+++ b/MyFlightbook.Telemetry.Tests/KMLParserTests.cs
@@ -75,5 +75,43 @@ namespace MyFlightbook.Telemetry.Tests
             Assert.AreEqual(47.621, Convert.ToDouble(parser.ParsedData.Rows[1][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
             Assert.AreEqual(-122.3501, Convert.ToDouble(parser.ParsedData.Rows[1][KnownColumnNames.LON], CultureInfo.InvariantCulture), 0.0001);
         }
+
+        [TestMethod]
+        public void Parse_GxTrackAcrossMultiplePlacemarks_ParsesAllTracks()
+        {
+            const string kml = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:09:26Z</when>
+                      <when>2025-03-14T19:10:26Z</when>
+                      <gx:coord>-122.3493 47.6205 376.2756</gx:coord>
+                      <gx:coord>-122.3501 47.6210 400</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                  <Placemark>
+                    <gx:Track>
+                      <when>2025-03-14T19:11:26Z</when>
+                      <gx:coord>-122.3510 47.6215 420</gx:coord>
+                    </gx:Track>
+                  </Placemark>
+                </kml>
+                """;
+
+            KMLParser parser = new KMLParser
+            {
+                ParsedData = new TelemetryDataTable()
+            };
+
+            bool parsed = parser.Parse(kml);
+
+            Assert.IsTrue(parsed, parser.ErrorString);
+            Assert.AreEqual(3, parser.ParsedData.Rows.Count);
+            Assert.AreEqual(DateTime.Parse("2025-03-14T19:11:26Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal),
+                (DateTime)parser.ParsedData.Rows[2][KnownColumnNames.TIME]);
+            Assert.AreEqual(47.6215, Convert.ToDouble(parser.ParsedData.Rows[2][KnownColumnNames.LAT], CultureInfo.InvariantCulture), 0.0001);
+            Assert.AreEqual(-122.3510, Convert.ToDouble(parser.ParsedData.Rows[2][KnownColumnNames.LON], CultureInfo.InvariantCulture), 0.0001);
+        }
     }
 }

--- a/MyFlightbook.Telemetry/KML.cs
+++ b/MyFlightbook.Telemetry/KML.cs
@@ -296,22 +296,26 @@ namespace MyFlightbook.Telemetry
         private bool ParseKMLv2(KMLElements k)
         {
             List<Position> lstSamples = new List<Position>();
-            using (IEnumerator<XElement> timestampEnumerator = k.ele22.Descendants(k.ns + "when").GetEnumerator())
+
+            foreach (XElement track in k.xmlDoc.Descendants(k.ns + "Placemark").Descendants(k.ns22 + "Track"))
             {
-                foreach (XElement coord in k.ele22.Descendants(k.ns22 + "coord"))
+                using (IEnumerator<XElement> timestampEnumerator = track.Descendants(k.ns + "when").GetEnumerator())
                 {
-                    string[] rgRow = coord.Value.Split(new char[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
-                    Position sample = new Position(rgRow);
-
-                    if (timestampEnumerator.MoveNext())
+                    foreach (XElement coord in track.Descendants(k.ns22 + "coord"))
                     {
-                        sample.TypeOfSpeed = Position.SpeedType.Derived;
-                        string szTimeStamp = timestampEnumerator.Current.Value;
-                        if (!String.IsNullOrEmpty(szTimeStamp))
-                            sample.Timestamp = szTimeStamp.ParseUTCDate();
-                    }
+                        string[] rgRow = coord.Value.Split(new char[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
+                        Position sample = new Position(rgRow);
 
-                    lstSamples.Add(sample);
+                        if (timestampEnumerator.MoveNext())
+                        {
+                            sample.TypeOfSpeed = Position.SpeedType.Derived;
+                            string szTimeStamp = timestampEnumerator.Current.Value;
+                            if (!String.IsNullOrEmpty(szTimeStamp))
+                                sample.Timestamp = szTimeStamp.ParseUTCDate();
+                        }
+
+                        lstSamples.Add(sample);
+                    }
                 }
             }
 

--- a/MyFlightbook.Telemetry/KML.cs
+++ b/MyFlightbook.Telemetry/KML.cs
@@ -293,66 +293,85 @@ namespace MyFlightbook.Telemetry
             return fResult;
         }
 
-        private bool ParseKMLv2(KMLElements k)
+        private static List<Position> ParseTrack(KMLElements k, XElement track)
         {
             List<Position> lstSamples = new List<Position>();
 
+            using (IEnumerator<XElement> timestampEnumerator = track.Descendants(k.ns + "when").GetEnumerator())
+            {
+                foreach (XElement coord in track.Descendants(k.ns22 + "coord"))
+                {
+                    string[] rgRow = coord.Value.Split(new char[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    Position sample = new Position(rgRow);
+
+                    if (timestampEnumerator.MoveNext())
+                    {
+                        sample.TypeOfSpeed = Position.SpeedType.Derived;
+                        string szTimeStamp = timestampEnumerator.Current.Value;
+                        if (!String.IsNullOrEmpty(szTimeStamp))
+                            sample.Timestamp = szTimeStamp.ParseUTCDate();
+                    }
+
+                    lstSamples.Add(sample);
+                }
+            }
+
+            // See if speed is available in this track's extended data; if so, it lines up by position with this track's own coordinates.
+            foreach (XElement e in track.Descendants(k.ns22 + "SimpleArrayData"))
+            {
+                var attr = e.Attribute("name");
+                if (attr != null && (String.Compare(attr.Value, "speedKts", StringComparison.OrdinalIgnoreCase) == 0 || String.Compare(attr.Value, "speed_kts", StringComparison.OrdinalIgnoreCase) == 0))
+                {
+                    int i = 0;
+                    int maxSample = lstSamples.Count;
+                    foreach (XElement speedval in e.Descendants())
+                    {
+                        string szVal = speedval.Value;
+                        if (i < maxSample && double.TryParse(szVal, out double sp))
+                        {
+                            Position p = lstSamples[i++];
+                            p.Speed = sp;
+                            p.TypeOfSpeed = Position.SpeedType.Reported;
+                        }
+                        else
+                            break;
+                    }
+                    break;  // no need to go through any other elements in extended data
+                }
+            }
+
+            return lstSamples;
+        }
+
+        private bool ParseKMLv2(KMLElements k)
+        {
+            // A document can contain more than one track (e.g., a merged file).  Parse each one on its own so its timestamps and reported speeds stay aligned with its own coordinates.
+            List<List<Position>> lstTracks = new List<List<Position>>();
             foreach (XElement track in k.xmlDoc.Descendants(k.ns + "Placemark").Descendants(k.ns22 + "Track"))
             {
-                using (IEnumerator<XElement> timestampEnumerator = track.Descendants(k.ns + "when").GetEnumerator())
-                {
-                    foreach (XElement coord in track.Descendants(k.ns22 + "coord"))
-                    {
-                        string[] rgRow = coord.Value.Split(new char[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
-                        Position sample = new Position(rgRow);
-
-                        if (timestampEnumerator.MoveNext())
-                        {
-                            sample.TypeOfSpeed = Position.SpeedType.Derived;
-                            string szTimeStamp = timestampEnumerator.Current.Value;
-                            if (!String.IsNullOrEmpty(szTimeStamp))
-                                sample.Timestamp = szTimeStamp.ParseUTCDate();
-                        }
-
-                        lstSamples.Add(sample);
-                    }
-                }
+                List<Position> lstTrack = ParseTrack(k, track);
+                if (lstTrack.Count >= 2)    // ignore single-point (or empty) placemarks; they aren't a path
+                    lstTracks.Add(lstTrack);
             }
 
-            // Derive speed or see if it is available in extended data.
-            bool fHasSpeed = false;
-
-            var extendedData = k.xmlDoc.Descendants(k.ns22 + "SimpleArrayData");
-            if (extendedData != null)
+            List<Position> lstSamples = new List<Position>();
+            if (lstTracks.Count > 0)
             {
-                // Go through the items to find speed
-                foreach (XElement e in extendedData)
-                {
-                    var attr = e.Attribute("name");
-                    if (attr != null && (String.Compare(attr.Value, "speedKts", StringComparison.OrdinalIgnoreCase) == 0 || String.Compare(attr.Value, "speed_kts", StringComparison.OrdinalIgnoreCase) == 0))
-                    {
-                        int i = 0;
-                        int maxSample = lstSamples.Count;
-                        foreach (XElement speedval in e.Descendants())
-                        {
-                            string szVal = speedval.Value;
-                            if (i < maxSample && double.TryParse(szVal, out double sp))
-                            {
-                                Position p = lstSamples[i++];
-                                p.Speed = sp;
-                                p.TypeOfSpeed = Position.SpeedType.Reported;
-                                fHasSpeed = true;
-                            }
-                            else
-                                break;
-                        }
-                        break;  // no need to go through any other elements in extended data
-                    }
-                }
+                // Only merge tracks that match the first one found: mixing timestamped with un-timestamped (or speed-carrying with speed-less) samples would force us down to the least common denominator, losing time and speed (and thus landing detection).
+                List<Position> firstTrack = lstTracks[0];
+                bool fTimed = firstTrack.TrueForAll(p => p.HasTimeStamp);
+                bool fSpeed = firstTrack.TrueForAll(p => p.HasSpeed);
+
+                IEnumerable<List<Position>> tracksToMerge = lstTracks.Where(t => t.TrueForAll(p => p.HasTimeStamp) == fTimed && t.TrueForAll(p => p.HasSpeed) == fSpeed);
+                if (fTimed)     // when timestamped, order the tracks chronologically (they can be out of order in the file)
+                    tracksToMerge = tracksToMerge.OrderBy(t => t[0].Timestamp);
+
+                foreach (List<Position> t in tracksToMerge)
+                    lstSamples.AddRange(t);
             }
 
-            // derive speed if we didn't find it above
-            if (!fHasSpeed)
+            // Derive speed if no track reported it.
+            if (!lstSamples.Any(p => p.HasSpeed))
                 Position.DeriveSpeed(lstSamples);
 
             // And put it into a data table


### PR DESCRIPTION
I download all of my flight tracks from FlightAware. For flights that contain full-stop landings, FlightAware reports these as multiple flights, so there are multiple track files. I then combine them with kmlmerger.com using the XML merge method.

These combined tracks contain more than one `<gx:Track>` placemark, so when uploaded to MyFlightbook only the first track is rendered on the map.

Updated after review feedback: each track is now parsed on its own, so its timestamps and reported speeds stay aligned with its own coordinates. Only tracks like the first one found (timestamps/speeds) get merged, timestamped tracks are inserted in time order, and single-point placemarks are ignored (which also means a file containing only a single point now parses to nothing).

Added unit tests for each of these cases.

Since already uploaded flights have their path cached in the `flightpath` column of the `flighttelemetry` table, this only fixes new uploads.
